### PR TITLE
Remove UTF8Error and Url Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::io;
 use std::error;
-use std::string::FromUtf8Error;
 
 use hyper;
 use rustc_serialize;
@@ -11,8 +10,6 @@ use rustc_serialize;
 pub enum Error {
     /// Http client error
     Http(hyper::Error),
-    /// Error decoding websocket text frame Utf8
-    Utf8(FromUtf8Error),
     /// Error parsing url
     Url(hyper::Error),
     /// Error decoding Json
@@ -60,17 +57,10 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<FromUtf8Error> for Error {
-    fn from(err: FromUtf8Error) -> Error {
-        Error::Utf8(err)
-    }
-}
-
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Http(ref e) => write!(f, "Http (hyper) Error: {:?}", e),
-            Error::Utf8(ref e) => write!(f, "Utf8 decode Error: {:?}", e),
             Error::Url(ref e) => write!(f, "Url Error: {:?}", e),
             Error::JsonDecode(ref e) => write!(f, "Json Decode Error: {:?}", e),
             Error::JsonParse(ref e) => write!(f, "Json Parse Error: {:?}", e),
@@ -85,7 +75,6 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Http(ref e) => e.description(),
-            Error::Utf8(ref e) => e.description(),
             Error::Url(ref e) => e.description(),
             Error::JsonDecode(ref e) => e.description(),
             Error::JsonParse(ref e) => e.description(),
@@ -98,7 +87,6 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Http(ref e) => Some(e),
-            Error::Utf8(ref e) => Some(e),
             Error::Url(ref e) => Some(e),
             Error::JsonDecode(ref e) => Some(e),
             Error::JsonParse(ref e) => Some(e),

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,8 +10,6 @@ use rustc_serialize;
 pub enum Error {
     /// Http client error
     Http(hyper::Error),
-    /// Error parsing url
-    Url(hyper::Error),
     /// Error decoding Json
     JsonDecode(rustc_serialize::json::DecoderError),
     /// Error parsing Json
@@ -26,10 +24,7 @@ pub enum Error {
 
 impl From<hyper::Error> for Error {
     fn from(err: hyper::Error) -> Error {
-        match err {
-            hyper::Error::Uri(_) => Error::Url(err),
-            _ => Error::Http(err)
-        }
+        Error::Http(err)
     }
 }
 
@@ -61,7 +56,6 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Http(ref e) => write!(f, "Http (hyper) Error: {:?}", e),
-            Error::Url(ref e) => write!(f, "Url Error: {:?}", e),
             Error::JsonDecode(ref e) => write!(f, "Json Decode Error: {:?}", e),
             Error::JsonParse(ref e) => write!(f, "Json Parse Error: {:?}", e),
             Error::JsonEncode(ref e) => write!(f, "Json Encode Error: {:?}", e),
@@ -75,7 +69,6 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Http(ref e) => e.description(),
-            Error::Url(ref e) => e.description(),
             Error::JsonDecode(ref e) => e.description(),
             Error::JsonParse(ref e) => e.description(),
             Error::JsonEncode(ref e) => e.description(),
@@ -87,7 +80,6 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::Http(ref e) => Some(e),
-            Error::Url(ref e) => Some(e),
             Error::JsonDecode(ref e) => Some(e),
             Error::JsonParse(ref e) => Some(e),
             Error::JsonEncode(ref e) => Some(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub type ApiResult<T> = Result<T, Error>;
 /// params. Returns the response body string after checking it has "ok": true, or an Error
 fn make_api_call<'a, T: Decodable>(client: &hyper::Client, method: &str, custom_params: HashMap<&str, &'a str>) -> ApiResult<T> {
     let url_string = format!("https://slack.com/api/{}", method);
-    let mut url = try!(hyper::Url::parse(&url_string).map_err(|e| hyper::Error::Uri(e)));
+    let mut url = hyper::Url::parse(&url_string).expect("Unable to parse url");
 
     url.set_query_from_pairs(custom_params.into_iter());
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -21,7 +21,7 @@ pub fn access(client: &hyper::Client, client_id: &str, client_secret: &str, code
         params.insert("redirect_uri", redirect_uri);
     }
 
-    let mut url = try!(hyper::Url::parse("https://slack.com/api/oauth.access").map_err(|e| hyper::Error::Uri(e)));
+    let mut url = hyper::Url::parse("https://slack.com/api/oauth.access").expect("Unable to parse url");
     url.set_query_from_pairs(params.into_iter());
 
     let response = try!(client.get(url).send());


### PR DESCRIPTION
UTF8Error should have already been removed. It's only an issue with websocket parsing which doesn't occur in this lib.

The url error is more of a "reducing the public API" change. It shouldn't ever happen because all of the URLs are controlled by the library. No user input ends up in URLs. If a URL fails to parse, something is fundamentally wrong, so we can just panic instead.