### PR TITLE
Add license header to source files

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Checks API calling code.
 //!
 //! For more information, see [Slack's API

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Checks authentication & identity.
 //!
 //! For more information, see [Slack's API

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,6 +1,19 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Get info on your team's Slack channels, create or archive channels, invite
-//! users, set the topic
-//! and purpose, and mark a channel as read.
+//! users, set the topic and purpose, and mark a channel as read.
 //!
 //! For more information, see [Slack's API
 //! documentation](https://api.slack.com/methods).

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Post chat messages to Slack.
 //!
 //! For more information, see [Slack's API

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! For more information, see [Slack's API
 //! documentation](https://api.slack.com/methods).
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt;
 use std::io;
 use std::error;

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rustc_serialize::{Decodable, Decoder};
 
 /// Represents Slack [rtm event](https://api.slack.com/rtm) types.

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Get info on files uploaded to Slack, upload new files to Slack.
 //!
 //! For more information, see [Slack's API

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Get info on your team's private groups.
 //!
 //! For more information, see [Slack's API

--- a/src/im.rs
+++ b/src/im.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Get info on your direct messages.
 //!
 //! For more information, see [Slack's API

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Low-level, direct interface for the [Slack Web
 //! API](https://api.slack.com/methods).
 

--- a/src/message_events.rs
+++ b/src/message_events.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rustc_serialize::{Decodable, Decoder};
 
 use std::collections::HashMap;

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! For more information, see [Slack's API
 //! documentation](https://api.slack.com/methods).
 

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! For more information, see [Slack's API
 //! documentation](https://api.slack.com/methods).
 

--- a/src/reactions.rs
+++ b/src/reactions.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! For more information, see [Slack's API
 //! documentation](https://api.slack.com/methods).
 

--- a/src/rtm.rs
+++ b/src/rtm.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! For more information, see [Slack's API
 //! documentation](https://api.slack.com/methods).
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Search your team's files and messages.
 //!
 //! For more information, see [Slack's API

--- a/src/stars.rs
+++ b/src/stars.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! For more information, see [Slack's API
 //! documentation](https://api.slack.com/methods).
 

--- a/src/team.rs
+++ b/src/team.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! For more information, see [Slack's API
 //! documentation](https://api.slack.com/methods).
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rustc_serialize::{Decodable, Decoder};
 
 /// The `Reaction` object as found in the [`File`](https://api.slack.com/types/file) type and some

--- a/src/users.rs
+++ b/src/users.rs
@@ -1,3 +1,17 @@
+// Copyright 2015-2016 the slack-rs authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Get info on members of your Slack team.
 //!
 //! For more information, see [Slack's API


### PR DESCRIPTION
I didn't add the license header to the `Cargo.toml`, just the actual `.rs` files. FWIW, this is what the official rust crates do as well: https://github.com/rust-lang-nursery.