### PR TITLE
Allow for a generic request sender instead of only allowing Hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ description = "Interface for the Slack Web API"
 license = "Apache-2.0"
 
 [dependencies]
-hyper = "0.8.0"
+hyper = { version = "0.8.0", optional = true }
 rustc-serialize = "0.3.18"
 
-[dev-dependencies]
-yup-hyper-mock = "1.3.2"
+[features]
+default = ["hyper"]

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -19,18 +19,17 @@
 //! documentation](https://api.slack.com/methods).
 
 use std::collections::HashMap;
-use hyper;
 
-use super::ApiResult;
-use super::make_authed_api_call;
+use super::{ApiResult, SlackWebRequestSender, parse_slack_response};
 
 /// Archives a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.archive
-pub fn archive(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<ArchiveResponse> {
+pub fn archive<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<ArchiveResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "channels.archive", token, params)
+    let response = try!(client.send_authed("channels.archive", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -39,10 +38,11 @@ pub struct ArchiveResponse;
 /// Creates a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.create
-pub fn create(client: &hyper::Client, token: &str, name: &str) -> ApiResult<CreateResponse> {
+pub fn create<R: SlackWebRequestSender>(client: &R, token: &str, name: &str) -> ApiResult<CreateResponse> {
     let mut params = HashMap::new();
     params.insert("name", name);
-    make_authed_api_call(client, "channels.create", token, params)
+    let response = try!(client.send_authed("channels.create", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -53,7 +53,7 @@ pub struct CreateResponse {
 /// Fetches history of messages and events from a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.history
-pub fn history(client: &hyper::Client,
+pub fn history<R: SlackWebRequestSender>(client: &R,
                token: &str,
                channel: &str,
                latest: Option<&str>,
@@ -81,7 +81,8 @@ pub fn history(client: &hyper::Client,
     if let Some(ref count) = count {
         params.insert("count", count);
     }
-    make_authed_api_call(client, "channels.history", token, params)
+    let response = try!(client.send_authed("channels.history", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -95,10 +96,11 @@ pub struct HistoryResponse {
 /// Gets information about a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.info
-pub fn info(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<InfoResponse> {
+pub fn info<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<InfoResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "channels.info", token, params)
+    let response = try!(client.send_authed("channels.info", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -109,11 +111,12 @@ pub struct InfoResponse {
 /// Invites a user to a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.invite
-pub fn invite(client: &hyper::Client, token: &str, channel: &str, user: &str) -> ApiResult<InviteResponse> {
+pub fn invite<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, user: &str) -> ApiResult<InviteResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("user", user);
-    make_authed_api_call(client, "channels.invite", token, params)
+    let response = try!(client.send_authed("channels.invite", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -124,10 +127,11 @@ pub struct InviteResponse {
 /// Joins a channel, creating it if needed.
 ///
 /// Wraps https://api.slack.com/methods/channels.join
-pub fn join(client: &hyper::Client, token: &str, name: &str) -> ApiResult<JoinResponse> {
+pub fn join<R: SlackWebRequestSender>(client: &R, token: &str, name: &str) -> ApiResult<JoinResponse> {
     let mut params = HashMap::new();
     params.insert("name", name);
-    make_authed_api_call(client, "channels.join", token, params)
+    let response = try!(client.send_authed("channels.join", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -139,11 +143,12 @@ pub struct JoinResponse {
 /// Removes a user from a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.kick
-pub fn kick(client: &hyper::Client, token: &str, channel: &str, user: &str) -> ApiResult<KickResponse> {
+pub fn kick<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, user: &str) -> ApiResult<KickResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("user", user);
-    make_authed_api_call(client, "channels.kick", token, params)
+    let response = try!(client.send_authed("channels.kick", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -152,10 +157,11 @@ pub struct KickResponse;
 /// Leaves a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.leave
-pub fn leave(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<LeaveResponse> {
+pub fn leave<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<LeaveResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "channels.leave", token, params)
+    let response = try!(client.send_authed("channels.leave", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -166,7 +172,7 @@ pub struct LeaveResponse {
 /// Lists all channels in a Slack team.
 ///
 /// Wraps https://api.slack.com/methods/channels.list
-pub fn list(client: &hyper::Client, token: &str, exclude_archived: Option<bool>) -> ApiResult<ListResponse> {
+pub fn list<R: SlackWebRequestSender>(client: &R, token: &str, exclude_archived: Option<bool>) -> ApiResult<ListResponse> {
     let mut params = HashMap::new();
     if let Some(exclude_archived) = exclude_archived {
         params.insert("exclude_archived",
@@ -176,7 +182,8 @@ pub fn list(client: &hyper::Client, token: &str, exclude_archived: Option<bool>)
                           "0"
                       });
     }
-    make_authed_api_call(client, "channels.list", token, params)
+    let response = try!(client.send_authed("channels.list", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -187,11 +194,12 @@ pub struct ListResponse {
 /// Sets the read cursor in a channel.
 ///
 /// https://api.slack.com/methods/channels.mark
-pub fn mark(client: &hyper::Client, token: &str, channel: &str, ts: &str) -> ApiResult<MarkResponse> {
+pub fn mark<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, ts: &str) -> ApiResult<MarkResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("ts", ts);
-    make_authed_api_call(client, "channels.mark", token, params)
+    let response = try!(client.send_authed("channels.mark", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -200,11 +208,12 @@ pub struct MarkResponse;
 /// Renames a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.rename
-pub fn rename(client: &hyper::Client, token: &str, channel: &str, name: &str) -> ApiResult<RenameResponse> {
+pub fn rename<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, name: &str) -> ApiResult<RenameResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("name", name);
-    make_authed_api_call(client, "channels.rename", token, params)
+    let response = try!(client.send_authed("channels.rename", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -223,11 +232,12 @@ pub struct RenameResponse {
 /// Sets the purpose for a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.setPurpose
-pub fn set_purpose(client: &hyper::Client, token: &str, channel: &str, purpose: &str) -> ApiResult<SetPurposeResponse> {
+pub fn set_purpose<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, purpose: &str) -> ApiResult<SetPurposeResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("purpose", purpose);
-    make_authed_api_call(client, "channels.setPurpose", token, params)
+    let response = try!(client.send_authed("channels.setPurpose", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -238,11 +248,12 @@ pub struct SetPurposeResponse {
 /// Sets the topic for a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.setTopic
-pub fn set_topic(client: &hyper::Client, token: &str, channel: &str, topic: &str) -> ApiResult<SetTopicResponse> {
+pub fn set_topic<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, topic: &str) -> ApiResult<SetTopicResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("topic", topic);
-    make_authed_api_call(client, "channels.setTopic", token, params)
+    let response = try!(client.send_authed("channels.setTopic", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -253,10 +264,11 @@ pub struct SetTopicResponse {
 /// Unarchives a channel.
 ///
 /// Wraps https://api.slack.com/methods/channels.unarchive
-pub fn unarchive(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<UnarchiveResponse> {
+pub fn unarchive<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<UnarchiveResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "channels.unarchive", token, params)
+    let response = try!(client.send_authed("channels.unarchive", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -264,32 +276,29 @@ pub struct UnarchiveResponse;
 
 #[cfg(test)]
 mod tests {
-    use hyper;
     use super::*;
     use super::super::Message;
-
-    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+    use super::super::test_helpers::*;
 
     #[test]
     fn general_api_error_response() {
-        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": false, "err": "some_error"}"#);
         let result = info(&client, "TEST_TOKEN", "TEST_CHANNEL");
         assert!(result.is_err());
     }
 
-    mock_slack_responder!(MockArchiveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn archive_ok_response() {
-        let client = hyper::Client::with_connector(MockArchiveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = archive(&client, "TEST_TOKEN", "TEST_CHANNEL");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockCreateOkResponder,
-        r#"{
+    #[test]
+    fn create_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "channel": {
                 "id": "C024BE91L",
@@ -318,12 +327,7 @@ mod tests {
                     "last_set": 0
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn create_ok_response() {
-        let client = hyper::Client::with_connector(MockCreateOkResponder::default());
+        }"#);
         let result = create(&client, "TEST_TOKEN", "TEST_CHANNEL");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -331,8 +335,9 @@ mod tests {
         assert!(result.unwrap().channel.id == "C024BE91L");
     }
 
-    mock_slack_responder!(MockHistoryOkResponder,
-        r#"{
+    #[test]
+    fn history_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "messages": [
                 {
@@ -349,12 +354,7 @@ mod tests {
                 }
             ],
             "has_more": true
-        }"#
-    );
-
-    #[test]
-    fn history_ok_response() {
-        let client = hyper::Client::with_connector(MockHistoryOkResponder::default());
+        }"#);
         let result = history(&client,
                              "TEST_TOKEN",
                              "TEST_CHANNEL",
@@ -366,15 +366,16 @@ mod tests {
             panic!(format!("{:?}", err));
         }
         match result.unwrap().messages[0].clone() {
-            Message::Standard { ts: _, channel: _, user: _, text, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+            Message::Standard { text, .. } => {
                 assert_eq!(text.unwrap(), "lol");
             }
             _ => panic!("Message decoded into incorrect variant."),
         }
     }
 
-    mock_slack_responder!(MockInfoOkResponder,
-        r#"{
+    #[test]
+    fn info_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "channel": {
                 "id": "C024BE91L",
@@ -403,12 +404,7 @@ mod tests {
                     "last_set": 0
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn info_ok_response() {
-        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
+        }"#);
         let result = info(&client, "TEST_TOKEN", "TEST_CHANNEL");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -416,8 +412,9 @@ mod tests {
         assert!(result.unwrap().channel.id == "C024BE91L");
     }
 
-    mock_slack_responder!(MockInviteOkResponder,
-        r#"{
+    #[test]
+    fn invite_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "channel": {
                 "id": "C024BE91L",
@@ -446,12 +443,7 @@ mod tests {
                     "last_set": 0
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn invite_ok_response() {
-        let client = hyper::Client::with_connector(MockInviteOkResponder::default());
+        }"#);
         let result = invite(&client, "TEST_TOKEN", "TEST_CHANNEL", "U12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -459,8 +451,9 @@ mod tests {
         assert!(result.unwrap().channel.id == "C024BE91L");
     }
 
-    mock_slack_responder!(MockJoinOkResponder,
-        r#"{
+    #[test]
+    fn join_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "channel": {
                 "id": "C024BE91L",
@@ -489,12 +482,7 @@ mod tests {
                     "last_set": 0
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn join_ok_response() {
-        let client = hyper::Client::with_connector(MockJoinOkResponder::default());
+        }"#);
         let result = join(&client, "TEST_TOKEN", "TEST_CHANNEL");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -502,30 +490,27 @@ mod tests {
         assert!(result.unwrap().channel.id == "C024BE91L");
     }
 
-    mock_slack_responder!(MockKickOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn kick_ok_response() {
-        let client = hyper::Client::with_connector(MockKickOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = kick(&client, "TEST_TOKEN", "TEST_CHANNEL", "U12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockLeaveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn leave_ok_response() {
-        let client = hyper::Client::with_connector(MockLeaveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = leave(&client, "TEST_TOKEN", "TEST_CHANNEL");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockListOkResponder,
-        r#"{
+    #[test]
+    fn list_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "channels": [
                 {
@@ -583,12 +568,7 @@ mod tests {
                     }
                 }
             ]
-        }"#
-    );
-
-    #[test]
-    fn list_ok_response() {
-        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        }"#);
         let result = list(&client, "TEST_TOKEN", None);
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -596,19 +576,18 @@ mod tests {
         assert!(result.unwrap().channels[1].id == "C024BE91J");
     }
 
-    mock_slack_responder!(MockMarkOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn mark_ok_response() {
-        let client = hyper::Client::with_connector(MockMarkOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = mark(&client, "TEST_TOKEN", "TEST_CHANNEL", "1234567890.123456");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockRenameOkResponder,
-        r#"{
+    #[test]
+    fn rename_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "channel": {
                 "id": "C024BE91J",
@@ -616,12 +595,7 @@ mod tests {
                 "name": "NEW_NAME",
                 "created": 1444102158
             }
-        }"#
-    );
-
-    #[test]
-    fn rename_ok_response() {
-        let client = hyper::Client::with_connector(MockRenameOkResponder::default());
+        }"#);
         let result = rename(&client, "TEST_TOKEN", "TEST_CHANNEL", "newname");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -629,16 +603,12 @@ mod tests {
         assert!(result.unwrap().channel.name == "NEW_NAME")
     }
 
-    mock_slack_responder!(MockSetPurposeOkResponder,
-        r#"{
-            "ok": true,
-            "purpose": "This is the new purpose!"
-        }"#
-    );
-
     #[test]
     fn set_purpose_ok_response() {
-        let client = hyper::Client::with_connector(MockSetPurposeOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{
+            "ok": true,
+            "purpose": "This is the new purpose!"
+        }"#);
         let result = set_purpose(&client,
                                  "TEST_TOKEN",
                                  "TEST_CHANNEL",
@@ -649,16 +619,12 @@ mod tests {
         assert!(result.unwrap().purpose == "This is the new purpose!")
     }
 
-    mock_slack_responder!(MockSetTopicOkResponder,
-        r#"{
-            "ok": true,
-            "topic": "This is the new topic!"
-        }"#
-    );
-
     #[test]
     fn set_topic_ok_response() {
-        let client = hyper::Client::with_connector(MockSetTopicOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{
+            "ok": true,
+            "topic": "This is the new topic!"
+        }"#);
         let result = set_topic(&client,
                                "TEST_TOKEN",
                                "TEST_CHANNEL",
@@ -669,11 +635,9 @@ mod tests {
         assert!(result.unwrap().topic == "This is the new topic!")
     }
 
-    mock_slack_responder!(MockUnarchiveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn unarchive_ok_response() {
-        let client = hyper::Client::with_connector(MockUnarchiveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = unarchive(&client, "TEST_TOKEN", "TEST_CHANNEL");
         if let Err(err) = result {
             panic!(format!("{:?}", err));

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -16,16 +16,15 @@
 //! documentation](https://api.slack.com/methods).
 
 use std::collections::HashMap;
-use hyper;
 
-use super::ApiResult;
-use super::make_authed_api_call;
+use super::{ApiResult, SlackWebRequestSender, parse_slack_response};
 
 /// Lists custom emoji for a team.
 ///
 /// Wraps https://api.slack.com/methods/emoji.list
-pub fn list(client: &hyper::Client, token: &str) -> ApiResult<ListResponse> {
-    make_authed_api_call(client, "emoji.list", token, HashMap::new())
+pub fn list<R: SlackWebRequestSender>(client: &R, token: &str) -> ApiResult<ListResponse> {
+    let response = try!(client.send_authed("emoji.list", token, HashMap::new()));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -35,32 +34,26 @@ pub struct ListResponse {
 
 #[cfg(test)]
 mod tests {
-    use hyper;
     use super::*;
-
-    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+    use super::super::test_helpers::*;
 
     #[test]
     fn general_api_error_response() {
-        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": false, "err": "some_error"}"#);
         let result = list(&client, "TEST_TOKEN");
         assert!(result.is_err());
     }
 
-    mock_slack_responder!(MockListOkResponder,
-        r#"{
+    #[test]
+    fn test_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "emoji": {
                 "bowtie": "https:\/\/my.slack.com\/emoji\/bowtie\/46ec6f2bb0.png",
                 "squirrel": "https:\/\/my.slack.com\/emoji\/squirrel\/f35f40c0e0.png",
                 "shipit": "alias:squirrel"
             }
-        }"#
-    );
-
-    #[test]
-    fn test_ok_response() {
-        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        }"#);
         let result = list(&client, "TEST_TOKEN");
         if let Err(err) = result {
             panic!(format!("{:?}", err));

--- a/src/files.rs
+++ b/src/files.rs
@@ -18,18 +18,17 @@
 //! documentation](https://api.slack.com/methods).
 
 use std::collections::HashMap;
-use hyper;
 
-use super::ApiResult;
-use super::make_authed_api_call;
+use super::{ApiResult, SlackWebRequestSender, parse_slack_response};
 
 /// Deletes a file.
 ///
 /// Wraps https://api.slack.com/methods/files.delete
-pub fn delete(client: &hyper::Client, token: &str, file: &str) -> ApiResult<DeleteResponse> {
+pub fn delete<R: SlackWebRequestSender>(client: &R, token: &str, file: &str) -> ApiResult<DeleteResponse> {
     let mut params = HashMap::new();
     params.insert("file", file);
-    make_authed_api_call(client, "files.delete", token, params)
+    let response = try!(client.send_authed("files.delete", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -38,7 +37,7 @@ pub struct DeleteResponse;
 /// Gets information about a team file.
 ///
 /// Wraps https://api.slack.com/methods/files.info
-pub fn info(client: &hyper::Client, token: &str, file: &str, count: Option<u32>, page: Option<u32>) -> ApiResult<InfoResponse> {
+pub fn info<R: SlackWebRequestSender>(client: &R, token: &str, file: &str, count: Option<u32>, page: Option<u32>) -> ApiResult<InfoResponse> {
     let count = count.map(|c| c.to_string());
     let page = page.map(|p| p.to_string());
     let mut params = HashMap::new();
@@ -49,7 +48,8 @@ pub fn info(client: &hyper::Client, token: &str, file: &str, count: Option<u32>,
     if let Some(ref page) = page {
         params.insert("page", page);
     }
-    make_authed_api_call(client, "files.info", token, params)
+    let response = try!(client.send_authed("files.info", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -62,7 +62,7 @@ pub struct InfoResponse {
 /// Lists & filters team files.
 ///
 /// Wraps https://api.slack.com/methods/files.list
-pub fn list(client: &hyper::Client,
+pub fn list<R: SlackWebRequestSender>(client: &R,
             token: &str,
             user: Option<&str>,
             ts_from: Option<&str>,
@@ -92,7 +92,8 @@ pub fn list(client: &hyper::Client,
     if let Some(ref page) = page {
         params.insert("page", page);
     }
-    make_authed_api_call(client, "files.list", token, params)
+    let response = try!(client.send_authed("files.list", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -105,7 +106,7 @@ pub struct ListResponse {
 // ///
 // /// Wraps https://api.slack.com/methods/files.upload
 // #[allow(unused_variables)]
-// pub fn upload(client: &hyper::Client, token: &str, file: Option<Vec<u8>>,
+// pub fn upload<R: SlackWebRequestSender>(client: &R, token: &str, file: Option<Vec<u8>>,
 // content: Option<&str>, filetype: Option<&str>, filename: Option<&str>,
 // title: Option<&str>, initial_comment: Option<&str>, channels: Option<&str>)
 // -> ApiResult<UploadResponse> {
@@ -119,111 +120,30 @@ pub struct ListResponse {
 
 #[cfg(test)]
 mod tests {
-    use hyper;
     use super::*;
-
-    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+    use super::super::test_helpers::*;
 
     #[test]
     fn general_api_error_response() {
-        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": false, "err": "some_error"}"#);
         let result = delete(&client, "TEST_TOKEN", "F12345678");
         assert!(result.is_err());
     }
 
-    mock_slack_responder!(MockDeleteOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn delete_ok_response() {
-        let client = hyper::Client::with_connector(MockDeleteOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = delete(&client, "TEST_TOKEN", "F12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockInfoOkResponder, r#"{
-        "ok": true,
-        "file": {
-            "id" : "F2147483862",
-            "timestamp" : 1356032811,
-
-            "name" : "file.htm",
-            "title" : "My HTML file",
-            "mimetype" : "text\/plain",
-            "filetype" : "text",
-            "pretty_type": "Text",
-            "user" : "U2147483697",
-
-            "mode" : "hosted",
-            "editable" : true,
-            "is_external": false,
-            "external_type": "",
-
-            "size" : 12345,
-
-            "url": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/1.png",
-            "url_download": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/download\/1.png",
-            "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
-            "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
-
-            "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
-            "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
-            "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
-            "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
-            "thumb_360_w": 100,
-            "thumb_360_h": 100,
-
-            "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
-            "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
-            "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
-            "preview_highlight" : "&lt;div class=\"sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
-            "lines" : 123,
-            "lines_more": 118,
-
-            "is_public": true,
-            "public_url_shared": false,
-            "channels": ["C024BE7LT"],
-            "groups": ["G12345"],
-            "initial_comment": {
-                "id": "Fc027BN9L9",
-                "timestamp": 1356032811,
-                "user": "U2147483697",
-                "comment": "This is a comment"
-            },
-            "num_stars": 7,
-            "is_starred": true
-        },
-        "comments": [
-            {
-                "id": "Fc027BN9L9",
-                "timestamp": 1356032811,
-                "user": "U2147483697",
-                "comment": "This is a comment"
-            }
-        ],
-        "paging": {
-            "count": 100,
-            "total": 2,
-            "page": 1,
-            "pages": 0
-        }
-    }"#);
-
     #[test]
     fn info_ok_response() {
-        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
-        let result = info(&client, "TEST_TOKEN", "F12345678", None, None);
-        if let Err(err) = result {
-            panic!(format!("{:?}", err));
-        }
-        assert_eq!(result.unwrap().file.id, "F2147483862");
-    }
-
-    mock_slack_responder!(MockListOkResponder, r#"{
-        "ok": true,
-        "files": [
-            {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
+            "ok": true,
+            "file": {
                 "id" : "F2147483862",
                 "timestamp" : 1356032811,
 
@@ -273,69 +193,142 @@ mod tests {
                 "num_stars": 7,
                 "is_starred": true
             },
-            {
-                "id": "F12345678",
-                "created": 1444929467,
-                "timestamp": 1444929467,
-                "name": "test_img.png",
-                "title": "test_img",
-                "mimetype": "image\/png",
-                "filetype": "png",
-                "pretty_type": "PNG",
-                "user": "U12345678",
-                "editable": false,
-                "size": 16153,
-                "mode": "hosted",
-                "is_external": false,
-                "external_type": "",
-                "is_public": true,
-                "public_url_shared": false,
-                "display_as_bot": false,
-                "username": "",
-                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
-                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
-                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
-                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
-                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
-                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
-                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
-                "thumb_360_w": 360,
-                "thumb_360_h": 28,
-                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
-                "thumb_480_w": 480,
-                "thumb_480_h": 37,
-                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
-                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
-                "thumb_720_w": 720,
-                "thumb_720_h": 56,
-                "image_exif_rotation": 1,
-                "original_w": 895,
-                "original_h": 69,
-                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
-                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
-                "channels": [
-                    "C12345678"
-                ],
-                "groups": [
-
-                ],
-                "ims": [
-
-                ],
-                "comments_count": 0
+            "comments": [
+                {
+                    "id": "Fc027BN9L9",
+                    "timestamp": 1356032811,
+                    "user": "U2147483697",
+                    "comment": "This is a comment"
+                }
+            ],
+            "paging": {
+                "count": 100,
+                "total": 2,
+                "page": 1,
+                "pages": 0
             }
-        ],
-        "paging": {
-            "count": 100,
-            "total": 295,
-            "page": 1,
-            "pages": 3
+        }"#);
+        let result = info(&client, "TEST_TOKEN", "F12345678", None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
         }
-    }"#);
+        assert_eq!(result.unwrap().file.id, "F2147483862");
+    }
 
     #[test]
     fn list_ok_response() {
-        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{
+            "ok": true,
+            "files": [
+                {
+                    "id" : "F2147483862",
+                    "timestamp" : 1356032811,
+
+                    "name" : "file.htm",
+                    "title" : "My HTML file",
+                    "mimetype" : "text\/plain",
+                    "filetype" : "text",
+                    "pretty_type": "Text",
+                    "user" : "U2147483697",
+
+                    "mode" : "hosted",
+                    "editable" : true,
+                    "is_external": false,
+                    "external_type": "",
+
+                    "size" : 12345,
+
+                    "url": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/1.png",
+                    "url_download": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/download\/1.png",
+                    "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+                    "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+                    "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+                    "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+                    "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+                    "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+                    "thumb_360_w": 100,
+                    "thumb_360_h": 100,
+
+                    "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+                    "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+                    "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+                    "preview_highlight" : "&lt;div class=\"sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+                    "lines" : 123,
+                    "lines_more": 118,
+
+                    "is_public": true,
+                    "public_url_shared": false,
+                    "channels": ["C024BE7LT"],
+                    "groups": ["G12345"],
+                    "initial_comment": {
+                        "id": "Fc027BN9L9",
+                        "timestamp": 1356032811,
+                        "user": "U2147483697",
+                        "comment": "This is a comment"
+                    },
+                    "num_stars": 7,
+                    "is_starred": true
+                },
+                {
+                    "id": "F12345678",
+                    "created": 1444929467,
+                    "timestamp": 1444929467,
+                    "name": "test_img.png",
+                    "title": "test_img",
+                    "mimetype": "image\/png",
+                    "filetype": "png",
+                    "pretty_type": "PNG",
+                    "user": "U12345678",
+                    "editable": false,
+                    "size": 16153,
+                    "mode": "hosted",
+                    "is_external": false,
+                    "external_type": "",
+                    "is_public": true,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "username": "",
+                    "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                    "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                    "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                    "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                    "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                    "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                    "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                    "thumb_360_w": 360,
+                    "thumb_360_h": 28,
+                    "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                    "thumb_480_w": 480,
+                    "thumb_480_h": 37,
+                    "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                    "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                    "thumb_720_w": 720,
+                    "thumb_720_h": 56,
+                    "image_exif_rotation": 1,
+                    "original_w": 895,
+                    "original_h": 69,
+                    "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                    "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                    "channels": [
+                        "C12345678"
+                    ],
+                    "groups": [
+
+                    ],
+                    "ims": [
+
+                    ],
+                    "comments_count": 0
+                }
+            ],
+            "paging": {
+                "count": 100,
+                "total": 295,
+                "page": 1,
+                "pages": 3
+            }
+        }"#);
         let result = list(&client, "TEST_TOKEN", None, None, None, None, None, None);
         if let Err(err) = result {
             panic!(format!("{:?}", err));

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -18,18 +18,17 @@
 //! documentation](https://api.slack.com/methods).
 
 use std::collections::HashMap;
-use hyper;
 
-use super::ApiResult;
-use super::make_authed_api_call;
+use super::{ApiResult, SlackWebRequestSender, parse_slack_response};
 
 /// Archives a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.archive
-pub fn archive(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<ArchiveResponse> {
+pub fn archive<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<ArchiveResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "groups.archive", token, params)
+    let response = try!(client.send_authed("groups.archive", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -38,10 +37,11 @@ pub struct ArchiveResponse;
 /// Closes a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.close
-pub fn close(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<CloseResponse> {
+pub fn close<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<CloseResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "groups.close", token, params)
+    let response = try!(client.send_authed("groups.close", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -53,10 +53,11 @@ pub struct CloseResponse {
 /// Creates a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.create
-pub fn create(client: &hyper::Client, token: &str, name: &str) -> ApiResult<CreateResponse> {
+pub fn create<R: SlackWebRequestSender>(client: &R, token: &str, name: &str) -> ApiResult<CreateResponse> {
     let mut params = HashMap::new();
     params.insert("name", name);
-    make_authed_api_call(client, "groups.create", token, params)
+    let response = try!(client.send_authed("groups.create", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -67,10 +68,11 @@ pub struct CreateResponse {
 /// Clones and archives a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.createChild
-pub fn create_child(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<CreateChildResponse> {
+pub fn create_child<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<CreateChildResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "groups.createChild", token, params)
+    let response = try!(client.send_authed("groups.createChild", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -81,7 +83,7 @@ pub struct CreateChildResponse {
 /// Fetches history of messages and events from a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.history
-pub fn history(client: &hyper::Client,
+pub fn history<R: SlackWebRequestSender>(client: &R,
                token: &str,
                channel: &str,
                latest: Option<&str>,
@@ -109,7 +111,8 @@ pub fn history(client: &hyper::Client,
     if let Some(ref count) = count {
         params.insert("count", count);
     }
-    make_authed_api_call(client, "groups.history", token, params)
+    let response = try!(client.send_authed("groups.history", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -124,10 +127,11 @@ pub struct HistoryResponse {
 /// Gets information about a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.info
-pub fn info(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<InfoResponse> {
+pub fn info<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<InfoResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "groups.info", token, params)
+    let response = try!(client.send_authed("groups.info", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -138,11 +142,12 @@ pub struct InfoResponse {
 /// Invites a user to a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.invite
-pub fn invite(client: &hyper::Client, token: &str, channel: &str, user: &str) -> ApiResult<InviteResponse> {
+pub fn invite<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, user: &str) -> ApiResult<InviteResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("user", user);
-    make_authed_api_call(client, "groups.invite", token, params)
+    let response = try!(client.send_authed("groups.invite", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -154,11 +159,12 @@ pub struct InviteResponse {
 /// Removes a user from a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.kick
-pub fn kick(client: &hyper::Client, token: &str, channel: &str, user: &str) -> ApiResult<KickResponse> {
+pub fn kick<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, user: &str) -> ApiResult<KickResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("user", user);
-    make_authed_api_call(client, "groups.kick", token, params)
+    let response = try!(client.send_authed("groups.kick", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -167,10 +173,11 @@ pub struct KickResponse;
 /// Leaves a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.leave
-pub fn leave(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<LeaveResponse> {
+pub fn leave<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<LeaveResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "groups.leave", token, params)
+    let response = try!(client.send_authed("groups.leave", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -179,7 +186,7 @@ pub struct LeaveResponse;
 /// Lists private groups that the calling user has access to.
 ///
 /// Wraps https://api.slack.com/methods/groups.list
-pub fn list(client: &hyper::Client, token: &str, exclude_archived: Option<bool>) -> ApiResult<ListResponse> {
+pub fn list<R: SlackWebRequestSender>(client: &R, token: &str, exclude_archived: Option<bool>) -> ApiResult<ListResponse> {
     let mut params = HashMap::new();
     if let Some(exclude_archived) = exclude_archived {
         params.insert("exclude_archived",
@@ -189,7 +196,8 @@ pub fn list(client: &hyper::Client, token: &str, exclude_archived: Option<bool>)
                           "0"
                       });
     }
-    make_authed_api_call(client, "groups.list", token, params)
+    let response = try!(client.send_authed("groups.list", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -200,11 +208,12 @@ pub struct ListResponse {
 /// Sets the read cursor in a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.mark
-pub fn mark(client: &hyper::Client, token: &str, channel: &str, ts: &str) -> ApiResult<MarkResponse> {
+pub fn mark<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, ts: &str) -> ApiResult<MarkResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("ts", ts);
-    make_authed_api_call(client, "groups.mark", token, params)
+    let response = try!(client.send_authed("groups.mark", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -213,10 +222,11 @@ pub struct MarkResponse;
 /// Opens a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.open
-pub fn open(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<OpenResponse> {
+pub fn open<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<OpenResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "groups.open", token, params)
+    let response = try!(client.send_authed("groups.open", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -228,11 +238,12 @@ pub struct OpenResponse {
 /// Renames a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.rename
-pub fn rename(client: &hyper::Client, token: &str, channel: &str, name: &str) -> ApiResult<RenameResponse> {
+pub fn rename<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, name: &str) -> ApiResult<RenameResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("name", name);
-    make_authed_api_call(client, "groups.rename", token, params)
+    let response = try!(client.send_authed("groups.rename", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -251,11 +262,12 @@ pub struct RenameResponse {
 /// Sets the purpose for a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.setPurpose
-pub fn set_purpose(client: &hyper::Client, token: &str, channel: &str, purpose: &str) -> ApiResult<SetPurposeResponse> {
+pub fn set_purpose<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, purpose: &str) -> ApiResult<SetPurposeResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("purpose", purpose);
-    make_authed_api_call(client, "groups.setPurpose", token, params)
+    let response = try!(client.send_authed("groups.setPurpose", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -266,11 +278,12 @@ pub struct SetPurposeResponse {
 /// Sets the topic for a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.setTopic
-pub fn set_topic(client: &hyper::Client, token: &str, channel: &str, topic: &str) -> ApiResult<SetTopicResponse> {
+pub fn set_topic<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str, topic: &str) -> ApiResult<SetTopicResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
     params.insert("topic", topic);
-    make_authed_api_call(client, "groups.setTopic", token, params)
+    let response = try!(client.send_authed("groups.setTopic", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -281,10 +294,11 @@ pub struct SetTopicResponse {
 /// Unarchives a private group.
 ///
 /// Wraps https://api.slack.com/methods/groups.unarchive
-pub fn unarchive(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<UnarchiveResponse> {
+pub fn unarchive<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<UnarchiveResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "groups.unarchive", token, params)
+    let response = try!(client.send_authed("groups.unarchive", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -292,52 +306,42 @@ pub struct UnarchiveResponse;
 
 #[cfg(test)]
 mod tests {
-    use hyper;
     use super::*;
     use super::super::Message;
-
-    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+    use super::super::test_helpers::*;
 
     #[test]
     fn general_api_error_response() {
-        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": false, "err": "some_error"}"#);
         let result = info(&client, "TEST_TOKEN", "G12345678");
         assert!(result.is_err());
     }
 
-    mock_slack_responder!(MockArchiveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn archive_ok_response() {
-        let client = hyper::Client::with_connector(MockArchiveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = archive(&client, "TEST_TOKEN", "G12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
-
-    mock_slack_responder!(MockCloseOkResponder, r#"{"ok": true}"#);
-
+    
     #[test]
     fn close_ok_response() {
-        let client = hyper::Client::with_connector(MockCloseOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = close(&client, "TEST_TOKEN", "G12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockCloseAlreadyClosedOkResponder,
-        r#"{
+    #[test]
+    fn close_already_closed_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "no_op": true,
             "already_closed": true
-        }"#
-    );
-
-    #[test]
-    fn close_already_closed_ok_response() {
-        let client = hyper::Client::with_connector(MockCloseAlreadyClosedOkResponder::default());
+        }"#);
         let result = close(&client, "TEST_TOKEN", "G12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -345,8 +349,9 @@ mod tests {
         assert_eq!(result.unwrap().already_closed.unwrap(), true);
     }
 
-    mock_slack_responder!(MockCreateOkResponder,
-        r#"{
+    #[test]
+    fn create_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "group": {
                 "id": "G12345678",
@@ -374,12 +379,7 @@ mod tests {
                     "last_set": 1360782804
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn create_ok_response() {
-        let client = hyper::Client::with_connector(MockCreateOkResponder::default());
+        }"#);
         let result = create(&client, "TEST_TOKEN", "G12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -387,8 +387,9 @@ mod tests {
         assert!(result.unwrap().group.id == "G12345678");
     }
 
-    mock_slack_responder!(MockCreateChildOkResponder,
-        r#"{
+    #[test]
+    fn create_child_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "group": {
                 "id": "G12345678",
@@ -416,12 +417,7 @@ mod tests {
                     "last_set": 1360782804
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn create_child_ok_response() {
-        let client = hyper::Client::with_connector(MockCreateChildOkResponder::default());
+        }"#);
         let result = create_child(&client, "TEST_TOKEN", "G12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -429,8 +425,9 @@ mod tests {
         assert!(result.unwrap().group.id == "G12345678");
     }
 
-    mock_slack_responder!(MockHistoryOkResponder,
-        r#"{
+    #[test]
+    fn history_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "latest": "1358547726.000003",
             "messages": [
@@ -454,12 +451,7 @@ mod tests {
                 }
             ],
             "has_more": false
-        }"#
-    );
-
-    #[test]
-    fn history_ok_response() {
-        let client = hyper::Client::with_connector(MockHistoryOkResponder::default());
+        }"#);
         let result = history(&client, "TEST_TOKEN", "G12345678", None, None, None, None);
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -472,8 +464,9 @@ mod tests {
         }
     }
 
-    mock_slack_responder!(MockInfoOkResponder,
-        r#"{
+    #[test]
+    fn info_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "group": {
                 "id": "G12345678",
@@ -501,12 +494,7 @@ mod tests {
                     "last_set": 1360782804
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn info_ok_response() {
-        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
+        }"#);
         let result = info(&client, "TEST_TOKEN", "G12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -514,8 +502,9 @@ mod tests {
         assert!(result.unwrap().group.id == "G12345678");
     }
 
-    mock_slack_responder!(MockInviteOkResponder,
-        r#"{
+    #[test]
+    fn invite_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "group": {
                 "id": "G12345678",
@@ -543,21 +532,17 @@ mod tests {
                     "last_set": 1360782804
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn invite_ok_response() {
-        let client = hyper::Client::with_connector(MockInviteOkResponder::default());
+        }"#);
         let result = invite(&client, "TEST_TOKEN", "G12345678", "U12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
         assert!(result.unwrap().group.id == "G12345678");
     }
-
-    mock_slack_responder!(MockInviteAlreadyInGroupOkResponder,
-        r#"{
+    
+    #[test]
+    fn invite_already_in_channel_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "already_in_group": true,
             "group": {
@@ -586,12 +571,7 @@ mod tests {
                     "last_set": 1360782804
                 }
             }
-        }"#
-    );
-
-    #[test]
-    fn invite_already_in_channel_ok_response() {
-        let client = hyper::Client::with_connector(MockInviteAlreadyInGroupOkResponder::default());
+        }"#);
         let result = invite(&client, "TEST_TOKEN", "G12345678", "U12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -599,30 +579,27 @@ mod tests {
         assert!(result.unwrap().already_in_group.unwrap() == true);
     }
 
-    mock_slack_responder!(MockKickOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn kick_ok_response() {
-        let client = hyper::Client::with_connector(MockKickOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = kick(&client, "TEST_TOKEN", "G12345678", "U12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockLeaveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn leave_ok_response() {
-        let client = hyper::Client::with_connector(MockLeaveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = leave(&client, "TEST_TOKEN", "G12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockListOkResponder,
-        r#"{
+    #[test]
+    fn list_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "groups": [
                 {
@@ -678,12 +655,7 @@ mod tests {
                     }
                 }
             ]
-        }"#
-    );
-
-    #[test]
-    fn list_ok_response() {
-        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        }"#);
         let result = list(&client, "TEST_TOKEN", None);
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -691,19 +663,18 @@ mod tests {
         assert!(result.unwrap().groups[1].id == "G87654321");
     }
 
-    mock_slack_responder!(MockMarkOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn mark_ok_response() {
-        let client = hyper::Client::with_connector(MockMarkOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = mark(&client, "TEST_TOKEN", "G12345678", "1234567890.123456");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockRenameOkResponder,
-        r#"{
+    #[test]
+    fn rename_ok_response() {
+        let client = MockSlackWebRequestSender::respond_with(r#"{
             "ok": true,
             "channel": {
                 "id": "C024BE91J",
@@ -711,12 +682,7 @@ mod tests {
                 "name": "NEW_NAME",
                 "created": 1444102158
             }
-        }"#
-    );
-
-    #[test]
-    fn rename_ok_response() {
-        let client = hyper::Client::with_connector(MockRenameOkResponder::default());
+        }"#);
         let result = rename(&client, "TEST_TOKEN", "G12345678", "newname");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -724,16 +690,12 @@ mod tests {
         assert!(result.unwrap().channel.name == "NEW_NAME")
     }
 
-    mock_slack_responder!(MockSetPurposeOkResponder,
-        r#"{
-            "ok": true,
-            "purpose": "This is the new purpose!"
-        }"#
-    );
-
     #[test]
     fn set_purpose_ok_response() {
-        let client = hyper::Client::with_connector(MockSetPurposeOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{
+            "ok": true,
+            "purpose": "This is the new purpose!"
+        }"#);
         let result = set_purpose(&client,
                                  "TEST_TOKEN",
                                  "G12345678",
@@ -744,16 +706,12 @@ mod tests {
         assert!(result.unwrap().purpose == "This is the new purpose!")
     }
 
-    mock_slack_responder!(MockSetTopicOkResponder,
-        r#"{
-            "ok": true,
-            "topic": "This is the new topic!"
-        }"#
-    );
-
     #[test]
     fn set_topic_ok_response() {
-        let client = hyper::Client::with_connector(MockSetTopicOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{
+            "ok": true,
+            "topic": "This is the new topic!"
+        }"#);
         let result = set_topic(&client, "TEST_TOKEN", "G12345678", "This is the new topic!");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -761,11 +719,9 @@ mod tests {
         assert!(result.unwrap().topic == "This is the new topic!")
     }
 
-    mock_slack_responder!(MockUnarchiveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn unarchive_ok_response() {
-        let client = hyper::Client::with_connector(MockUnarchiveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = unarchive(&client, "TEST_TOKEN", "G12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,37 +15,21 @@
 //! Low-level, direct interface for the [Slack Web
 //! API](https://api.slack.com/methods).
 
-extern crate hyper;
 extern crate rustc_serialize;
 
-#[cfg(test)] #[macro_use]
-extern crate yup_hyper_mock;
+#[cfg(feature = "hyper")]
+extern crate hyper;
 
 use std::collections::HashMap;
-use std::io::Read;
-
 use rustc_serialize::{json, Decodable};
 
-#[cfg(test)]
-#[macro_use]
-pub mod test_helpers {
-    macro_rules! mock_slack_responder {
-        ($name:ident, $json:expr) => {
-            mock_connector!($name {
-                "https://slack.com" => "HTTP/1.1 200 OK\r\n\r\n".to_owned() + $json
-            });
-        }
-    }
-}
-
 mod types;
-pub use self::types::*;
-
 mod error;
-pub use error::Error;
-
 mod message_events;
+
+pub use self::types::*;
 pub use self::message_events::Message;
+pub use self::error::{Error, HttpRequestError};
 
 pub mod api;
 pub mod auth;
@@ -66,41 +50,107 @@ pub mod users;
 
 pub type ApiResult<T> = Result<T, Error>;
 
-/// Make an API call to Slack. Takes a map of parameters that get appended to the request as query
-/// params. Returns the response body string after checking it has "ok": true, or an Error
-fn make_api_call<'a, T: Decodable>(client: &hyper::Client, method: &str, custom_params: HashMap<&str, &'a str>) -> ApiResult<T> {
-    let url_string = format!("https://slack.com/api/{}", method);
-    let mut url = hyper::Url::parse(&url_string).expect("Unable to parse url");
-
-    url.set_query_from_pairs(custom_params.into_iter());
-
-    let response = try!(client.get(url).send());
-    transform_api_result(response)
-}
-
-/// Make an API call to Slack that includes the configured token. Takes a map of parameters that
-/// get appended to the request as query params. Returns the response body string after checking it
-/// has `"ok": true`, or an Error
-fn make_authed_api_call<'a, T: Decodable>(client: &hyper::Client, method: &str, token: &'a str, mut custom_params: HashMap<&str, &'a str>) -> ApiResult<T> {
-    custom_params.insert("token", token);
-    make_api_call(client, method, custom_params)
-}
-
-fn transform_api_result<T: Decodable>(mut res: hyper::client::response::Response) -> ApiResult<T> {
-    let mut res_str = String::new();
-    try!(res.read_to_string(&mut res_str));
-
-    let raw_json = try!(json::Json::from_str(&res_str));
+fn parse_slack_response<T: Decodable>(response: String, check_ok: bool) -> ApiResult<T> {
+    let raw_json = try!(json::Json::from_str(&response));
     let jobj = try!(raw_json.as_object()
-                            .ok_or(Error::Api(format!("bad slack json response (not an object) {:?}", raw_json))));
-    let ok = try!(jobj.get("ok")
-                      .ok_or(Error::Api(format!("slack json reponse does not contain \"ok\" field {:?}",
-                                                raw_json))));
-    let is_ok = try!(ok.as_boolean()
-                       .ok_or(Error::Api(format!("slack json reponse \"ok\" is not a boolean: {:?}", raw_json))));
-    if !is_ok {
-        return Err(Error::Api(format!("slack json reponse \"ok\" is not true: {:?}", raw_json)));
+                            .ok_or(Error::Api(format!("bad slack json response (not an \
+                                                       object) {:?}",
+                                                      raw_json))));
+    if check_ok {
+        let ok = try!(jobj.get("ok")
+                          .ok_or(Error::Api(format!("slack json reponse does not contain \
+                                                     \"ok\" field {:?}",
+                                                    raw_json))));
+        let is_ok = try!(ok.as_boolean()
+                           .ok_or(Error::Api(format!("slack json reponse \"ok\" is not a \
+                                                      boolean: {:?}",
+                                                     raw_json))));
+        if !is_ok {
+            return Err(Error::Api(format!("slack json reponse \"ok\" is not true: {:?}",
+                                          raw_json)));
+        }
     }
 
-    Ok(try!(json::decode(&res_str)))
+    Ok(try!(json::decode(&response)))
+}
+
+/// Functionality for sending authenticated and unauthenticated requests to Slack via HTTP.
+///
+/// Should be implemented for clients to send requests to Slack.
+pub trait SlackWebRequestSender {
+    /// Make an API call to Slack. Takes a map of parameters that get appended to the request as query
+    /// params. Returns the response body string after checking it has "ok": true, or an Error
+    fn send<'a>(&self, method: &str, params: HashMap<&str, &'a str>) -> Result<String, HttpRequestError>;
+
+    /// Make an API call to Slack that includes the configured token. Takes a map of parameters that
+    /// get appended to the request as query params. Returns the response body string after checking it
+    /// has `"ok": true`, or an Error
+    fn send_authed<'a>(&self,
+                       method: &str,
+                       token: &'a str,
+                       mut params: HashMap<&str, &'a str>)
+                       -> Result<String, HttpRequestError> {
+        params.insert("token", token);
+        self.send(method, params)
+    }
+}
+
+#[cfg(feature = "hyper")]
+mod hyper_support {
+    use hyper;
+    use std::collections::HashMap;
+    use std::io::Read;
+    
+    use super::{SlackWebRequestSender, HttpRequestError};
+    
+    impl SlackWebRequestSender for hyper::Client {
+        fn send<'a>(&self, method: &str, params: HashMap<&str, &'a str>) -> Result<String, HttpRequestError> {
+            let url_string = format!("https://slack.com/api/{}", method);
+            let mut url = hyper::Url::parse(&url_string).expect("Unable to parse url");
+
+            url.set_query_from_pairs(params.into_iter());
+
+            let mut response = try!(self.get(url).send());
+            let mut res_str = String::new();
+            try!(response.read_to_string(&mut res_str));
+
+            Ok(res_str)
+        }
+    }
+    
+    impl From<hyper::Error> for HttpRequestError {
+        fn from(err: hyper::Error) -> HttpRequestError {
+            match err {
+                hyper::Error::Io(e) => HttpRequestError::Io(e),
+                e => panic!("Unexpected Hyper request error: {}", e)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "hyper")]
+pub use hyper_support::*;
+
+#[cfg(test)]
+mod test_helpers {
+    use std::collections::HashMap;
+    use super::{SlackWebRequestSender, HttpRequestError};
+    
+    pub struct MockSlackWebRequestSender {
+        response: String
+    }
+
+    impl MockSlackWebRequestSender {
+        pub fn respond_with<S: Into<String>>(response: S) -> Self {
+            MockSlackWebRequestSender {
+                response: response.into()
+            }
+        }
+    }
+
+    impl SlackWebRequestSender for MockSlackWebRequestSender {
+        fn send<'b>(&self, _: &str, _: HashMap<&str, &'b str>) -> Result<String, HttpRequestError> {
+            Ok(self.response.clone())
+        }
+    }
 }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -16,17 +16,13 @@
 //! documentation](https://api.slack.com/methods).
 
 use std::collections::HashMap;
-use std::io::Read;
-use hyper;
-use rustc_serialize::json;
 
-use super::ApiResult;
-use error::Error;
+use super::{ApiResult, SlackWebRequestSender, parse_slack_response};
 
 /// Exchanges a temporary OAuth code for an API token.
 ///
 /// Wraps https://api.slack.com/methods/oauth.access
-pub fn access(client: &hyper::Client, client_id: &str, client_secret: &str, code: &str, redirect_uri: Option<&str>) -> ApiResult<AccessResponse> {
+pub fn access<R: SlackWebRequestSender>(client: &R, client_id: &str, client_secret: &str, code: &str, redirect_uri: Option<&str>) -> ApiResult<AccessResponse> {
     let mut params = HashMap::new();
     params.insert("client_id", client_id);
     params.insert("client_secret", client_secret);
@@ -34,30 +30,9 @@ pub fn access(client: &hyper::Client, client_id: &str, client_secret: &str, code
     if let Some(redirect_uri) = redirect_uri {
         params.insert("redirect_uri", redirect_uri);
     }
-
-    let mut url = hyper::Url::parse("https://slack.com/api/oauth.access").expect("Unable to parse url");
-    url.set_query_from_pairs(params.into_iter());
-
-    let response = try!(client.get(url).send());
-    transform_oauth_response(response)
-}
-
-fn transform_oauth_response(mut res: hyper::client::response::Response) -> ApiResult<AccessResponse> {
-    let mut res_str = String::new();
-    try!(res.read_to_string(&mut res_str));
-
-    let raw_json = try!(json::Json::from_str(&res_str));
-    let jobj = try!(raw_json.as_object()
-                            .ok_or(Error::Api(format!("bad slack json response (not an object) {:?}", raw_json))));
-    if let Some(ok) = jobj.get("ok") {
-        let is_ok = try!(ok.as_boolean()
-                           .ok_or(Error::Api(format!("slack json reponse \"ok\" is not a boolean: {:?}", raw_json))));
-        if !is_ok {
-            return Err(Error::Api(format!("slack json reponse \"ok\" is not true: {:?}", raw_json)));
-        }
-    }
-
-    Ok(try!(json::decode(&res_str)))
+    
+    let response = try!(client.send("oauth.access", params));
+    parse_slack_response(response, false)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -68,28 +43,22 @@ pub struct AccessResponse {
 
 #[cfg(test)]
 mod tests {
-    use hyper;
     use super::*;
-
-    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+    use super::super::test_helpers::*;
 
     #[test]
     fn general_api_error_response() {
-        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": false, "err": "some_error"}"#);
         let result = access(&client, "TEST_ID", "TEST_TOKEN", "TEST_CODE", None);
         assert!(result.is_err());
     }
 
-    mock_slack_responder!(MockListOkResponder,
-        r#"{
-            "access_token": "xoxt-23984754863-2348975623103",
-            "scope": "read"
-        }"#
-    );
-
     #[test]
     fn access_ok_response() {
-        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{
+            "access_token": "xoxt-23984754863-2348975623103",
+            "scope": "read"
+        }"#);
         let result = access(&client, "TEST_ID", "TEST_TOKEN", "TEST_CODE", None);
         if let Err(err) = result {
             panic!(format!("{:?}", err));

--- a/src/pins.rs
+++ b/src/pins.rs
@@ -16,15 +16,13 @@
 //! documentation](https://api.slack.com/methods).
 
 use std::collections::HashMap;
-use hyper;
 
-use super::ApiResult;
-use super::make_authed_api_call;
+use super::{ApiResult, SlackWebRequestSender, parse_slack_response};
 
 /// Pins an item to a channel.
 ///
 /// Wraps https://api.slack.com/methods/pins.add
-pub fn add(client: &hyper::Client,
+pub fn add<R: SlackWebRequestSender>(client: &R,
            token: &str,
            channel: &str,
            file: Option<&str>,
@@ -42,7 +40,8 @@ pub fn add(client: &hyper::Client,
     if let Some(timestamp) = timestamp {
         params.insert("timestamp", timestamp);
     }
-    make_authed_api_call(client, "pins.add", token, params)
+    let response = try!(client.send_authed("pins.add", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -51,10 +50,11 @@ pub struct AddResponse;
 /// Lists items pinned to a channel.
 ///
 /// Wraps https://api.slack.com/methods/pins.list
-pub fn list(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<ListResponse> {
+pub fn list<R: SlackWebRequestSender>(client: &R, token: &str, channel: &str) -> ApiResult<ListResponse> {
     let mut params = HashMap::new();
     params.insert("channel", channel);
-    make_authed_api_call(client, "pins.list", token, params)
+    let response = try!(client.send_authed("pins.list", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -65,7 +65,7 @@ pub struct ListResponse {
 /// Un-pins an item from a channel.
 ///
 /// Wraps https://api.slack.com/methods/pins.remove
-pub fn remove(client: &hyper::Client,
+pub fn remove<R: SlackWebRequestSender>(client: &R,
               token: &str,
               channel: &str,
               file: Option<&str>,
@@ -83,7 +83,8 @@ pub fn remove(client: &hyper::Client,
     if let Some(timestamp) = timestamp {
         params.insert("timestamp", timestamp);
     }
-    make_authed_api_call(client, "pins.remove", token, params)
+    let response = try!(client.send_authed("pins.remove", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -91,24 +92,20 @@ pub struct RemoveResponse;
 
 #[cfg(test)]
 mod tests {
-    use hyper;
     use super::*;
     use super::super::Item;
-
-    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+    use super::super::test_helpers::*;
 
     #[test]
     fn general_api_error_response() {
-        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": false, "err": "some_error"}"#);
         let result = list(&client, "TEST_TOKEN", "TEST_CHANNEL");
         assert!(result.is_err());
     }
 
-    mock_slack_responder!(MockAddOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn add_ok_response() {
-        let client = hyper::Client::with_connector(MockAddOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = add(&client,
                          "TEST_TOKEN",
                          "TEST_CHANNEL",
@@ -120,139 +117,137 @@ mod tests {
         }
     }
 
-    mock_slack_responder!(MockListOkResponder, r#"{
-        "ok": true,
-        "items": [
-            {
-                "type": "message",
-                "channel": "C2147483705",
-                "message": {
-                    "type": "message",
-                    "user": "U024BE7LH",
-                    "text": "lol",
-                    "ts": "1444078138.000084"
-                }
-            },
-            {
-                "type": "file",
-                "file": {
-                    "id": "F12345678",
-                    "created": 1444929467,
-                    "timestamp": 1444929467,
-                    "name": "test_img.png",
-                    "title": "test_img",
-                    "mimetype": "image\/png",
-                    "filetype": "png",
-                    "pretty_type": "PNG",
-                    "user": "U12345678",
-                    "editable": false,
-                    "size": 16153,
-                    "mode": "hosted",
-                    "is_external": false,
-                    "external_type": "",
-                    "is_public": true,
-                    "public_url_shared": false,
-                    "display_as_bot": false,
-                    "username": "",
-                    "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
-                    "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
-                    "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
-                    "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
-                    "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
-                    "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
-                    "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
-                    "thumb_360_w": 360,
-                    "thumb_360_h": 28,
-                    "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
-                    "thumb_480_w": 480,
-                    "thumb_480_h": 37,
-                    "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
-                    "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
-                    "thumb_720_w": 720,
-                    "thumb_720_h": 56,
-                    "image_exif_rotation": 1,
-                    "original_w": 895,
-                    "original_h": 69,
-                    "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
-                    "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
-                    "channels": [
-                        "C12345678"
-                    ],
-                    "groups": [
-
-                    ],
-                    "ims": [
-
-                    ],
-                    "comments_count": 0
-                }
-            },
-            {
-                "type": "file_comment",
-                "file": {
-                    "id": "F12345678",
-                    "created": 1444929467,
-                    "timestamp": 1444929467,
-                    "name": "test_img.png",
-                    "title": "test_img",
-                    "mimetype": "image\/png",
-                    "filetype": "png",
-                    "pretty_type": "PNG",
-                    "user": "U12345678",
-                    "editable": false,
-                    "size": 16153,
-                    "mode": "hosted",
-                    "is_external": false,
-                    "external_type": "",
-                    "is_public": true,
-                    "public_url_shared": false,
-                    "display_as_bot": false,
-                    "username": "",
-                    "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
-                    "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
-                    "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
-                    "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
-                    "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
-                    "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
-                    "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
-                    "thumb_360_w": 360,
-                    "thumb_360_h": 28,
-                    "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
-                    "thumb_480_w": 480,
-                    "thumb_480_h": 37,
-                    "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
-                    "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
-                    "thumb_720_w": 720,
-                    "thumb_720_h": 56,
-                    "image_exif_rotation": 1,
-                    "original_w": 895,
-                    "original_h": 69,
-                    "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
-                    "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
-                    "channels": [
-                        "C12345678"
-                    ],
-                    "groups": [
-
-                    ],
-                    "ims": [
-
-                    ],
-                    "comments_count": 0
-                },
-                "comment": {
-                    "id": "Fc12345678",
-                    "timestamp": 1356032811,
-                    "user": "U12345678",
-                    "comment": "This is a comment"
-                }
-            }
-        ]
-    }"#);
-
     #[test]
     fn list_ok_response() {
-        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{
+            "ok": true,
+            "items": [
+                {
+                    "type": "message",
+                    "channel": "C2147483705",
+                    "message": {
+                        "type": "message",
+                        "user": "U024BE7LH",
+                        "text": "lol",
+                        "ts": "1444078138.000084"
+                    }
+                },
+                {
+                    "type": "file",
+                    "file": {
+                        "id": "F12345678",
+                        "created": 1444929467,
+                        "timestamp": 1444929467,
+                        "name": "test_img.png",
+                        "title": "test_img",
+                        "mimetype": "image\/png",
+                        "filetype": "png",
+                        "pretty_type": "PNG",
+                        "user": "U12345678",
+                        "editable": false,
+                        "size": 16153,
+                        "mode": "hosted",
+                        "is_external": false,
+                        "external_type": "",
+                        "is_public": true,
+                        "public_url_shared": false,
+                        "display_as_bot": false,
+                        "username": "",
+                        "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                        "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                        "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                        "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                        "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                        "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                        "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                        "thumb_360_w": 360,
+                        "thumb_360_h": 28,
+                        "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                        "thumb_480_w": 480,
+                        "thumb_480_h": 37,
+                        "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                        "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                        "thumb_720_w": 720,
+                        "thumb_720_h": 56,
+                        "image_exif_rotation": 1,
+                        "original_w": 895,
+                        "original_h": 69,
+                        "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                        "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                        "channels": [
+                            "C12345678"
+                        ],
+                        "groups": [
+
+                        ],
+                        "ims": [
+
+                        ],
+                        "comments_count": 0
+                    }
+                },
+                {
+                    "type": "file_comment",
+                    "file": {
+                        "id": "F12345678",
+                        "created": 1444929467,
+                        "timestamp": 1444929467,
+                        "name": "test_img.png",
+                        "title": "test_img",
+                        "mimetype": "image\/png",
+                        "filetype": "png",
+                        "pretty_type": "PNG",
+                        "user": "U12345678",
+                        "editable": false,
+                        "size": 16153,
+                        "mode": "hosted",
+                        "is_external": false,
+                        "external_type": "",
+                        "is_public": true,
+                        "public_url_shared": false,
+                        "display_as_bot": false,
+                        "username": "",
+                        "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                        "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                        "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                        "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                        "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                        "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                        "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                        "thumb_360_w": 360,
+                        "thumb_360_h": 28,
+                        "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                        "thumb_480_w": 480,
+                        "thumb_480_h": 37,
+                        "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                        "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                        "thumb_720_w": 720,
+                        "thumb_720_h": 56,
+                        "image_exif_rotation": 1,
+                        "original_w": 895,
+                        "original_h": 69,
+                        "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                        "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                        "channels": [
+                            "C12345678"
+                        ],
+                        "groups": [
+
+                        ],
+                        "ims": [
+
+                        ],
+                        "comments_count": 0
+                    },
+                    "comment": {
+                        "id": "Fc12345678",
+                        "timestamp": 1356032811,
+                        "user": "U12345678",
+                        "comment": "This is a comment"
+                    }
+                }
+            ]
+        }"#);
         let result = list(&client, "TEST_TOKEN", "TEST_CHANNEL");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -263,11 +258,9 @@ mod tests {
         }
     }
 
-    mock_slack_responder!(MockRemoveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn remove_ok_response() {
-        let client = hyper::Client::with_connector(MockRemoveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = remove(&client,
                             "TEST_TOKEN",
                             "TEST_CHANNEL",

--- a/src/stars.rs
+++ b/src/stars.rs
@@ -16,15 +16,13 @@
 //! documentation](https://api.slack.com/methods).
 
 use std::collections::HashMap;
-use hyper;
 
-use super::ApiResult;
-use super::make_authed_api_call;
+use super::{ApiResult, SlackWebRequestSender, parse_slack_response};
 
 /// Adds a star to an item.
 ///
 /// Wraps https://api.slack.com/methods/stars.add
-pub fn add(client: &hyper::Client,
+pub fn add<R: SlackWebRequestSender>(client: &R,
            token: &str,
            file: Option<&str>,
            file_comment: Option<&str>,
@@ -44,7 +42,8 @@ pub fn add(client: &hyper::Client,
     if let Some(timestamp) = timestamp {
         params.insert("timestamp", timestamp);
     }
-    make_authed_api_call(client, "stars.add", token, params)
+    let response = try!(client.send_authed("stars.add", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -53,7 +52,7 @@ pub struct AddResponse;
 /// Lists stars for a user.
 ///
 /// Wraps https://api.slack.com/methods/stars.list
-pub fn list(client: &hyper::Client, token: &str, user: Option<&str>, count: Option<u32>, page: Option<u32>) -> ApiResult<ListResponse> {
+pub fn list<R: SlackWebRequestSender>(client: &R, token: &str, user: Option<&str>, count: Option<u32>, page: Option<u32>) -> ApiResult<ListResponse> {
     let count = count.map(|c| c.to_string());
     let page = page.map(|p| p.to_string());
     let mut params = HashMap::new();
@@ -66,7 +65,8 @@ pub fn list(client: &hyper::Client, token: &str, user: Option<&str>, count: Opti
     if let Some(ref page) = page {
         params.insert("page", page);
     }
-    make_authed_api_call(client, "stars.list", token, params)
+    let response = try!(client.send_authed("stars.list", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -78,7 +78,7 @@ pub struct ListResponse {
 /// Removes a star from an item.
 ///
 /// Wraps https://api.slack.com/methods/stars.remove
-pub fn remove(client: &hyper::Client,
+pub fn remove<R: SlackWebRequestSender>(client: &R,
               token: &str,
               file: Option<&str>,
               file_comment: Option<&str>,
@@ -98,7 +98,8 @@ pub fn remove(client: &hyper::Client,
     if let Some(timestamp) = timestamp {
         params.insert("timestamp", timestamp);
     }
-    make_authed_api_call(client, "stars.remove", token, params)
+    let response = try!(client.send_authed("stars.remove", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -106,15 +107,13 @@ pub struct RemoveResponse;
 
 #[cfg(test)]
 mod tests {
-    use hyper;
     use super::*;
     use super::super::StarredItem;
-
-    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+    use super::super::test_helpers::*;
 
     #[test]
     fn general_api_error_response() {
-        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": false, "err": "some_error"}"#);
         let result = add(&client,
                          "TEST_TOKEN",
                          None,
@@ -124,11 +123,9 @@ mod tests {
         assert!(result.is_err());
     }
 
-    mock_slack_responder!(MockAddOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn add_ok_response() {
-        let client = hyper::Client::with_connector(MockAddOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = add(&client,
                          "TEST_TOKEN",
                          None,
@@ -140,90 +137,88 @@ mod tests {
         }
     }
 
-    mock_slack_responder!(MockListOkResponder, r#"
-        {
-            "ok": true,
-            "items": [
-                {
-                    "type": "message",
-                    "channel": "C2147483705",
-                    "message": {
-                        "ts": "12345",
-                        "user": "123",
-                        "text": "something"
-                    }
-                },
-                {
-                    "type": "file",
-                    "file": {
-                        "id": "F12345678",
-                        "created": 1444929467,
-                        "timestamp": 1444929467,
-                        "name": "test_img.png",
-                        "title": "test_img",
-                        "mimetype": "image\/png",
-                        "filetype": "png",
-                        "pretty_type": "PNG",
-                        "user": "U12345678",
-                        "editable": false,
-                        "size": 16153,
-                        "mode": "hosted",
-                        "is_external": false,
-                        "external_type": "",
-                        "is_public": true,
-                        "public_url_shared": false,
-                        "display_as_bot": false,
-                        "username": "",
-                        "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
-                        "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
-                        "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
-                        "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
-                        "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
-                        "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
-                        "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
-                        "thumb_360_w": 360,
-                        "thumb_360_h": 28,
-                        "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
-                        "thumb_480_w": 480,
-                        "thumb_480_h": 37,
-                        "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
-                        "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
-                        "thumb_720_w": 720,
-                        "thumb_720_h": 56,
-                        "image_exif_rotation": 1,
-                        "original_w": 895,
-                        "original_h": 69,
-                        "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
-                        "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
-                        "channels": [
-                            "C12345678"
-                        ],
-                        "groups": [
-
-                        ],
-                        "ims": [
-
-                        ],
-                        "comments_count": 0
-                    }
-                },
-                {
-                    "type": "channel",
-                    "channel": "C2147483705"
-                }
-            ],
-            "paging": {
-                "count": 100,
-                "total": 15,
-                "page": 1,
-                "pages": 1
-            }
-        }
-    "#);
-
     #[test]
     fn list_ok_response() {
-        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"
+            {
+                "ok": true,
+                "items": [
+                    {
+                        "type": "message",
+                        "channel": "C2147483705",
+                        "message": {
+                            "ts": "12345",
+                            "user": "123",
+                            "text": "something"
+                        }
+                    },
+                    {
+                        "type": "file",
+                        "file": {
+                            "id": "F12345678",
+                            "created": 1444929467,
+                            "timestamp": 1444929467,
+                            "name": "test_img.png",
+                            "title": "test_img",
+                            "mimetype": "image\/png",
+                            "filetype": "png",
+                            "pretty_type": "PNG",
+                            "user": "U12345678",
+                            "editable": false,
+                            "size": 16153,
+                            "mode": "hosted",
+                            "is_external": false,
+                            "external_type": "",
+                            "is_public": true,
+                            "public_url_shared": false,
+                            "display_as_bot": false,
+                            "username": "",
+                            "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                            "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                            "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                            "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                            "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                            "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                            "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                            "thumb_360_w": 360,
+                            "thumb_360_h": 28,
+                            "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                            "thumb_480_w": 480,
+                            "thumb_480_h": 37,
+                            "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                            "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                            "thumb_720_w": 720,
+                            "thumb_720_h": 56,
+                            "image_exif_rotation": 1,
+                            "original_w": 895,
+                            "original_h": 69,
+                            "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                            "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                            "channels": [
+                                "C12345678"
+                            ],
+                            "groups": [
+
+                            ],
+                            "ims": [
+
+                            ],
+                            "comments_count": 0
+                        }
+                    },
+                    {
+                        "type": "channel",
+                        "channel": "C2147483705"
+                    }
+                ],
+                "paging": {
+                    "count": 100,
+                    "total": 15,
+                    "page": 1,
+                    "pages": 1
+                }
+            }
+        "#);
         let result = list(&client, "TEST_TOKEN", None, None, None);
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -234,11 +229,9 @@ mod tests {
         }
     }
 
-    mock_slack_responder!(MockRemoveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn remove_ok_response() {
-        let client = hyper::Client::with_connector(MockRemoveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = remove(&client,
                             "TEST_TOKEN",
                             None,

--- a/src/users.rs
+++ b/src/users.rs
@@ -18,18 +18,17 @@
 //! documentation](https://api.slack.com/methods).
 
 use std::collections::HashMap;
-use hyper;
 
-use super::ApiResult;
-use super::make_authed_api_call;
+use super::{ApiResult, SlackWebRequestSender, parse_slack_response};
 
 /// Gets user presence information.
 ///
 /// Wraps https://api.slack.com/methods/users.getPresence
-pub fn get_presence(client: &hyper::Client, token: &str, user: &str) -> ApiResult<GetPresenceResponse> {
+pub fn get_presence<R: SlackWebRequestSender>(client: &R, token: &str, user: &str) -> ApiResult<GetPresenceResponse> {
     let mut params = HashMap::new();
     params.insert("user", user);
-    make_authed_api_call(client, "users.getPresence", token, params)
+    let response = try!(client.send_authed( "users.getPresence", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -45,10 +44,11 @@ pub struct GetPresenceResponse {
 /// Gets information about a user.
 ///
 /// Wraps https://api.slack.com/methods/users.info
-pub fn info(client: &hyper::Client, token: &str, user: &str) -> ApiResult<InfoResponse> {
+pub fn info<R: SlackWebRequestSender>(client: &R, token: &str, user: &str) -> ApiResult<InfoResponse> {
     let mut params = HashMap::new();
     params.insert("user", user);
-    make_authed_api_call(client, "users.info", token, params)
+    let response = try!(client.send_authed( "users.info", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -59,7 +59,7 @@ pub struct InfoResponse {
 /// Lists all users in a Slack team.
 ///
 /// Wraps https://api.slack.com/methods/users.list
-pub fn list(client: &hyper::Client, token: &str, presence: Option<bool>) -> ApiResult<ListResponse> {
+pub fn list<R: SlackWebRequestSender>(client: &R, token: &str, presence: Option<bool>) -> ApiResult<ListResponse> {
     let mut params = HashMap::new();
     if let Some(presence) = presence {
         params.insert("presence",
@@ -69,7 +69,8 @@ pub fn list(client: &hyper::Client, token: &str, presence: Option<bool>) -> ApiR
                           "0"
                       });
     }
-    make_authed_api_call(client, "users.list", token, params)
+    let response = try!(client.send_authed( "users.list", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -80,8 +81,9 @@ pub struct ListResponse {
 /// Marks a user as active.
 ///
 /// Wraps https://api.slack.com/methods/users.setActive
-pub fn set_active(client: &hyper::Client, token: &str) -> ApiResult<SetActiveResponse> {
-    make_authed_api_call(client, "users.setActive", token, HashMap::new())
+pub fn set_active<R: SlackWebRequestSender>(client: &R, token: &str) -> ApiResult<SetActiveResponse> {
+    let response = try!(client.send_authed( "users.setActive", token, HashMap::new()));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -90,10 +92,11 @@ pub struct SetActiveResponse;
 /// Manually sets user presence.
 ///
 /// Wraps https://api.slack.com/methods/users.setPresence
-pub fn set_presence(client: &hyper::Client, token: &str, presence: &str) -> ApiResult<SetPresenceResponse> {
+pub fn set_presence<R: SlackWebRequestSender>(client: &R, token: &str, presence: &str) -> ApiResult<SetPresenceResponse> {
     let mut params = HashMap::new();
     params.insert("presence", presence);
-    make_authed_api_call(client, "users.setPresence", token, params)
+    let response = try!(client.send_authed( "users.setPresence", token, params));
+    parse_slack_response(response, true)
 }
 
 #[derive(Clone,Debug,RustcDecodable)]
@@ -101,28 +104,24 @@ pub struct SetPresenceResponse;
 
 #[cfg(test)]
 mod tests {
-    use hyper;
     use super::*;
-
-    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+    use super::super::test_helpers::*;
 
     #[test]
     fn general_api_error_response() {
-        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": false, "err": "some_error"}"#);
         let result = get_presence(&client, "TEST_TOKEN", "U12345678");
         assert!(result.is_err());
     }
 
-    mock_slack_responder!(MockGetPresenceOkResponder, r#"
-        {
-            "ok": true,
-            "presence": "active"
-        }
-    "#);
-
     #[test]
     fn get_presence_ok_response() {
-        let client = hyper::Client::with_connector(MockGetPresenceOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"
+            {
+                "ok": true,
+                "presence": "active"
+            }
+        "#);
         let result = get_presence(&client, "TEST_TOKEN", "U12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -130,21 +129,19 @@ mod tests {
         assert_eq!(result.unwrap().presence, "active");
     }
 
-    mock_slack_responder!(MockGetPresenceAuthedUserOkResponder, r#"
-        {
-            "ok": true,
-            "presence": "active",
-            "online": true,
-            "auto_away": false,
-            "manual_away": false,
-            "connection_count": 1,
-            "last_activity": 1419027078
-        }
-    "#);
-
     #[test]
     fn get_presence_authed_user_ok_response() {
-        let client = hyper::Client::with_connector(MockGetPresenceAuthedUserOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"
+            {
+                "ok": true,
+                "presence": "active",
+                "online": true,
+                "auto_away": false,
+                "manual_away": false,
+                "connection_count": 1,
+                "last_activity": 1419027078
+            }
+        "#);
         let result = get_presence(&client, "TEST_TOKEN", "U12345678");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -154,53 +151,12 @@ mod tests {
         assert_eq!(result.last_activity.unwrap(), 1419027078);
     }
 
-    mock_slack_responder!(MockInfoOkResponder, r#"
-        {
-            "ok": true,
-            "user": {
-                "id": "U023BECGF",
-                "name": "bobby",
-                "deleted": false,
-                "color": "9f69e7",
-                "profile": {
-                    "first_name": "Bobby",
-                    "last_name": "Tables",
-                    "real_name": "Bobby Tables",
-                    "email": "bobby@slack.com",
-                    "skype": "my-skype-name",
-                    "phone": "+1 (123) 456 7890",
-                    "image_24": "https:\/\/...",
-                    "image_32": "https:\/\/...",
-                    "image_48": "https:\/\/...",
-                    "image_72": "https:\/\/...",
-                    "image_192": "https:\/\/..."
-                },
-                "is_admin": true,
-                "is_owner": true,
-                "has_2fa": true,
-                "has_files": true
-            }
-        }
-    "#);
-
     #[test]
     fn info_ok_response() {
-        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
-        let result = info(&client, "TEST_TOKEN", "U12345678");
-        if let Err(err) = result {
-            panic!(format!("{:?}", err));
-        }
-        let result = result.unwrap();
-        assert_eq!(result.user.id, "U023BECGF");
-        assert_eq!(result.user.profile.email.as_ref().unwrap(),
-                   "bobby@slack.com");
-    }
-
-    mock_slack_responder!(MockListOkResponder, r#"
-        {
-            "ok": true,
-            "members": [
-                {
+        let client = MockSlackWebRequestSender::respond_with(r#"
+            {
+                "ok": true,
+                "user": {
                     "id": "U023BECGF",
                     "name": "bobby",
                     "deleted": false,
@@ -222,37 +178,74 @@ mod tests {
                     "is_owner": true,
                     "has_2fa": true,
                     "has_files": true
-                },
-                {
-                    "id": "U12345678",
-                    "name": "alice",
-                    "deleted": false,
-                    "color": "9f69e7",
-                    "profile": {
-                        "first_name": "Alice",
-                        "last_name": "Aardvark",
-                        "real_name": "Alice Aardvark",
-                        "email": "alice@slack.com",
-                        "skype": "my-skype-name",
-                        "phone": "+1 (123) 456 7890",
-                        "image_24": "https:\/\/...",
-                        "image_32": "https:\/\/...",
-                        "image_48": "https:\/\/...",
-                        "image_72": "https:\/\/...",
-                        "image_192": "https:\/\/..."
-                    },
-                    "is_admin": true,
-                    "is_owner": true,
-                    "has_2fa": true,
-                    "has_files": true
                 }
-            ]
+            }
+        "#);
+        let result = info(&client, "TEST_TOKEN", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
         }
-    "#);
+        let result = result.unwrap();
+        assert_eq!(result.user.id, "U023BECGF");
+        assert_eq!(result.user.profile.email.as_ref().unwrap(),
+                   "bobby@slack.com");
+    }
 
     #[test]
     fn list_ok_response() {
-        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"
+            {
+                "ok": true,
+                "members": [
+                    {
+                        "id": "U023BECGF",
+                        "name": "bobby",
+                        "deleted": false,
+                        "color": "9f69e7",
+                        "profile": {
+                            "first_name": "Bobby",
+                            "last_name": "Tables",
+                            "real_name": "Bobby Tables",
+                            "email": "bobby@slack.com",
+                            "skype": "my-skype-name",
+                            "phone": "+1 (123) 456 7890",
+                            "image_24": "https:\/\/...",
+                            "image_32": "https:\/\/...",
+                            "image_48": "https:\/\/...",
+                            "image_72": "https:\/\/...",
+                            "image_192": "https:\/\/..."
+                        },
+                        "is_admin": true,
+                        "is_owner": true,
+                        "has_2fa": true,
+                        "has_files": true
+                    },
+                    {
+                        "id": "U12345678",
+                        "name": "alice",
+                        "deleted": false,
+                        "color": "9f69e7",
+                        "profile": {
+                            "first_name": "Alice",
+                            "last_name": "Aardvark",
+                            "real_name": "Alice Aardvark",
+                            "email": "alice@slack.com",
+                            "skype": "my-skype-name",
+                            "phone": "+1 (123) 456 7890",
+                            "image_24": "https:\/\/...",
+                            "image_32": "https:\/\/...",
+                            "image_48": "https:\/\/...",
+                            "image_72": "https:\/\/...",
+                            "image_192": "https:\/\/..."
+                        },
+                        "is_admin": true,
+                        "is_owner": true,
+                        "has_2fa": true,
+                        "has_files": true
+                    }
+                ]
+            }
+        "#);
         let result = list(&client, "TEST_TOKEN", None);
         if let Err(err) = result {
             panic!(format!("{:?}", err));
@@ -263,22 +256,18 @@ mod tests {
                    "bobby@slack.com");
     }
 
-    mock_slack_responder!(MockSetActiveOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn set_active_ok_response() {
-        let client = hyper::Client::with_connector(MockSetActiveOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = set_active(&client, "TEST_TOKEN");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }
     }
 
-    mock_slack_responder!(MockSetPresenceOkResponder, r#"{"ok": true}"#);
-
     #[test]
     fn set_presence_ok_response() {
-        let client = hyper::Client::with_connector(MockSetPresenceOkResponder::default());
+        let client = MockSlackWebRequestSender::respond_with(r#"{"ok": true}"#);
         let result = set_presence(&client, "TEST_TOKEN", "active");
         if let Err(err) = result {
             panic!(format!("{:?}", err));


### PR DESCRIPTION
### Motivation
* Allows users to use clients other than Hyper to send requests if they choose
* Allows users to create their own sender implementation that wraps the existing Hyper one, perhaps to log outgoing requests.
* Lets us drop `yup-hyper-mock` as a dependency, as it was causing dependency version issues. The tests are simplified as a result.

### Breaking Changes
* Errors have changed quite a bit. Error::Internal is gone. Error::Http has been replaced with Error::HttpRequest, which now contains an HttpRequestError instead of a hyper::Error. This is to allow SlackWebRequestSender implementors to only need to implement a conversion of their client's errors into HttpRequestError. In addition, the error enums now contain a non-exhaustive hidden field. This allows future expansion of the enums without needing to make future breaking changes.

cc: @BenTheElder @kiyoto 