### PR TITLE
update hyper to 0.9.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Interface for the Slack Web API"
 license = "Apache-2.0"
 
 [dependencies]
-hyper = "0.8.0"
+hyper = "0.9.4"
 rustc-serialize = "0.3.18"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ fn make_api_call<'a, T: Decodable>(client: &hyper::Client, method: &str, custom_
     let url_string = format!("https://slack.com/api/{}", method);
     let mut url = hyper::Url::parse(&url_string).expect("Unable to parse url");
 
-    url.set_query_from_pairs(custom_params.into_iter());
+    url.query_pairs_mut().extend_pairs(custom_params.into_iter());
 
     let response = try!(client.get(url).send());
     transform_api_result(response)

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -36,7 +36,7 @@ pub fn access(client: &hyper::Client, client_id: &str, client_secret: &str, code
     }
 
     let mut url = hyper::Url::parse("https://slack.com/api/oauth.access").expect("Unable to parse url");
-    url.set_query_from_pairs(params.into_iter());
+    url.query_pairs_mut().extend_pairs(params.into_iter());
 
     let response = try!(client.get(url).send());
     transform_oauth_response(response)


### PR DESCRIPTION
There was a small API change going to 0.9.4 but this passes all the tests and I was successfully able to use the update locally.