### PR TITLE
usage of delete is backwards in api test

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -189,7 +189,7 @@ mod tests {
             "channel": "C024BE91L",
             "ts": "1401383885.000061"
         }"#);
-        let result = delete(&client, "TEST_TOKEN", "TEST_CHANNEL", "1401383885.000061");
+        let result = delete(&client, "TEST_TOKEN", "1401383885.000061", "C024BE91L");
         if let Err(err) = result {
             panic!(format!("{:?}", err));
         }


### PR DESCRIPTION
As with the slack-rs crate fix the thing is being used backwards. quite common when everything is strings.

I notice the tests don't really do anything that useful. the test only fails if the signature changes or the client is never used.
would it be acceptable to put debug asserts or at least debug logging if APIs are used obviously wrongly such as in this case? the actual thing is correct, it's just so easy to use backwards by accident.