### PR TITLE
PinnedItems do not always have a channel field

### DIFF
--- a/src/message_events.rs
+++ b/src/message_events.rs
@@ -207,7 +207,7 @@ pub enum Message {
         item_type: String,
         text: String,
         item: Option<super::Item>,
-        channel: String,
+        channel: Option<String>,
         ts: String,
         attachments: Option<Vec<super::Attachment>>,
     },


### PR DESCRIPTION
In using this API, I would sometimes get channels that would not report history from `slack_api::channels::history()`, returning `Err(JsonDecode(MissingFieldError("channel")))`. I tracked this down to `PinnedItem`, which did not appear to return a channel value.

The API document linked [`pinned_item`](https://api.slack.com/events/message/pinned_item) seems to imply that channel is not optional, however I am not sure if this is an unintentional regression. Using a similar Python API, I receive the following JSON item back:

```JSON
{
    "attachments": [
        {
            "author_icon": "..",
            "author_link": "..",
            "author_name": "James Munns",
            "author_subname": "james",
            "channel_id": "..",
            "channel_name": "general",
            "fallback": "..",
            "is_msg_unfurl": true,
            "mrkdwn_in": [
                "text"
            ],
            "text": "..",
            "ts": "1487556363.000305"
        }
    ],
    "item_type": "C",
    "subtype": "pinned_item",
    "text": "<@..|..> pinned a message to this channel.",
    "ts": "1487571577.000311",
    "type": "message",
    "user": ".."
}
```