### PR TITLE
override optional hash maps deserialize

### DIFF
--- a/codegen/src/generator.rs
+++ b/codegen/src/generator.rs
@@ -490,6 +490,10 @@ impl JsonObjectFieldInfo {
             prefix.push_str(&format!("#[serde(deserialize_with = \"{}\")]\n", path));
         }
 
+        if self.default {
+            prefix.push_str("#[serde(default)]\n");
+        }
+
         if self.name == "ok" {
             prefix.push_str("#[serde(default)]");
         } else if self.name != "error" && self.name != "ok" {

--- a/codegen/src/generator.rs
+++ b/codegen/src/generator.rs
@@ -485,11 +485,17 @@ impl Param {
 impl JsonObjectFieldInfo {
     pub fn to_code(&self) -> String {
         let mut prefix = String::new();
+
+        if let Some(ref path) = self.deserialize_with {
+            prefix.push_str(&format!("#[serde(deserialize_with = \"{}\")]\n", path));
+        }
+
         if self.name == "ok" {
             prefix.push_str("#[serde(default)]");
         } else if self.name != "error" && self.name != "ok" {
             prefix.push_str("pub");
         };
+        
         if let Some(ref rename) = self.rename {
             format!(
                 "#[serde(rename = \"{}\")]\n{} {}: {},",

--- a/codegen/src/json_schema.rs
+++ b/codegen/src/json_schema.rs
@@ -38,6 +38,7 @@ pub struct JsonObjectFieldInfo {
     pub ty: PropType,
     pub rename: Option<String>,
     pub deserialize_with: Option<&'static str>,
+    pub default: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -152,18 +153,21 @@ impl PropType {
                                         ty = PropType::Optional(Box::new(ty));
                                     }
                                     // Hack for slack bug which writes empty map as empty array
-                                    let deserialize_with = {
-                                        if name == "UserProfile" && field_name == "fields" {
-                                            Some("::optional_struct_or_empty_array")
-                                        } else {
-                                            None
-                                        }
-                                    };
+                                    let default;
+                                    let deserialize_with;
+                                    if name == "UserProfile" && field_name == "fields" {
+                                        deserialize_with = Some("::optional_struct_or_empty_array");
+                                        default = true;
+                                    } else {
+                                        deserialize_with = None;
+                                        default = false;
+                                    }
                                     JsonObjectFieldInfo {
                                         name: field_name.into(),
                                         ty: ty,
                                         rename: rename,
                                         deserialize_with: deserialize_with,
+                                        default: default,
                                     }
                                 })
                                 .collect();

--- a/codegen/src/json_schema.rs
+++ b/codegen/src/json_schema.rs
@@ -37,6 +37,7 @@ pub struct JsonObjectFieldInfo {
     pub name: String,
     pub ty: PropType,
     pub rename: Option<String>,
+    pub deserialize_with: Option<&'static str>,
 }
 
 #[derive(Clone, Debug)]
@@ -154,6 +155,7 @@ impl PropType {
                                         name: field_name.into(),
                                         ty: ty,
                                         rename: rename,
+                                        deserialize_with: None,
                                     }
                                 })
                                 .collect();

--- a/codegen/src/json_schema.rs
+++ b/codegen/src/json_schema.rs
@@ -151,11 +151,19 @@ impl PropType {
                                     } else {
                                         ty = PropType::Optional(Box::new(ty));
                                     }
+                                    // Hack for slack bug which writes empty map as empty array
+                                    let deserialize_with = {
+                                        if name == "UserProfile" && field_name == "fields" {
+                                            Some("::optional_struct_or_empty_array")
+                                        } else {
+                                            None
+                                        }
+                                    };
                                     JsonObjectFieldInfo {
                                         name: field_name.into(),
                                         ty: ty,
                                         rename: rename,
-                                        deserialize_with: None,
+                                        deserialize_with: deserialize_with,
                                     }
                                 })
                                 .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,18 +65,48 @@ fn optional_struct_or_empty_array<'de, T, D>(deserializer: D) -> Result<Option<T
             Ok(None)
         }
 
-        fn visit_none<E>(self) -> Result<Option<T>, E>
-            where E: de::Error
-        {
-            Ok(None)
-        }
-
         fn visit_map<M>(self, visitor: M) -> Result<Option<T>, M::Error>
             where M: de::MapVisitor
         {
-            de::Deserialize::deserialize(de::value::MapVisitorDeserializer::new(visitor)).map(Some)
+            T::deserialize(de::value::MapVisitorDeserializer::new(visitor)).map(Some)
         }
     }
 
     deserializer.deserialize(StructOrEmptyArray(PhantomData))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+    use super::UserProfile;
+
+    #[test]
+    fn test_user_profile_fields_empty_array_deserialize() {
+        let user_profile: UserProfile = serde_json::from_str(r#"{"fields": []}"#).unwrap();
+        assert_eq!(0, user_profile.fields.unwrap().len());
+    }
+
+    #[test]
+    fn test_user_profile_fields_empty_map_deserialize() {
+        let user_profile: UserProfile = serde_json::from_str(r#"{"fields": {}}"#).unwrap();
+        assert_eq!(0, user_profile.fields.unwrap().len());
+    }
+
+    #[test]
+    fn test_user_profile_fields_nonempty_map_deserialize() {
+        let user_profile: UserProfile = serde_json::from_str(r#"{"fields": {"some_field": {"alt": "foo", "label": "bar"}}}"#).unwrap();
+        assert_eq!(1, user_profile.fields.unwrap().len());
+    }
+
+    #[test]
+    fn test_user_profile_fields_null_deserialize() {
+        let user_profile: UserProfile = serde_json::from_str(r#"{"fields": null}"#).unwrap();
+        assert!(user_profile.fields.is_none());
+    }
+
+    #[test]
+    fn test_user_profile_fields_undefined_deserialize() {
+        let user_profile: UserProfile = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(user_profile.fields.is_none());
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -887,6 +887,7 @@ pub struct UsergroupPrefs {
 #[derive(Clone, Debug, Deserialize)]
 pub struct UserProfile {
     pub email: Option<String>,
+    #[serde(deserialize_with = "::optional_struct_or_empty_array")]
     pub fields: Option<HashMap<String, UserProfileFields>>,
     pub first_name: Option<String>,
     pub image_1024: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -888,6 +888,7 @@ pub struct UsergroupPrefs {
 pub struct UserProfile {
     pub email: Option<String>,
     #[serde(deserialize_with = "::optional_struct_or_empty_array")]
+    #[serde(default)]
     pub fields: Option<HashMap<String, UserProfileFields>>,
     pub first_name: Option<String>,
     pub image_1024: Option<String>,


### PR DESCRIPTION
custom deserialize for optional hashmaps optional_struct_or_empty_array
currently the only hashmap in the whole thing is profile fields (<-- wrong) but if they add more do we trust them to not write out [] sometimes? hmmm



didn't noticed you'd done a custom one at 1am but i thought i should understand serde better so i gave this a try. This will change the deserializer for all `Optional<HashMap` so if any are added in the future there's no need to customise them also