### PR TITLE
Export reqwest crate for easier usage of SlackWebRequestSender impl

### DIFF
--- a/src/requests.rs
+++ b/src/requests.rs
@@ -13,7 +13,7 @@ pub trait SlackWebRequestSender {
 
 #[cfg(feature = "reqwest")]
 mod reqwest_support {
-    extern crate reqwest;
+    pub extern crate reqwest;
 
     use std::io::Read;
 

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -13,7 +13,9 @@ pub trait SlackWebRequestSender {
 
 #[cfg(feature = "reqwest")]
 mod reqwest_support {
-    pub extern crate reqwest;
+    extern crate reqwest;
+    pub use self::reqwest::Client;
+    pub use self::reqwest::Error;
 
     use std::io::Read;
 
@@ -33,6 +35,10 @@ mod reqwest_support {
 
             Ok(res_str)
         }
+    }
+
+    pub fn default_client() -> Result<reqwest::Client, reqwest::Error> {
+        reqwest::Client::new()
     }
 }
 


### PR DESCRIPTION
Trying to use a 'directly imported' `reqwest::Client` with slack-rs-api might fail if your `reqwest` version doesn't match the one used by slack-rs-client (see also slack-rs/slack-rs#81). Re-exporting should help with that.