### PR TITLE
Remove non-existing message field from reactions::ListResponseItemMessage

### DIFF
--- a/src/mods/reactions.rs
+++ b/src/mods/reactions.rs
@@ -610,7 +610,6 @@ pub struct ListResponseItemFileComment {
 #[derive(Clone, Debug, Deserialize)]
 pub struct ListResponseItemMessage {
     pub channel: String,
-    pub message: ::Message,
     #[serde(rename = "type")]
     pub ty: String,
 }


### PR DESCRIPTION
I got this error when receiving reactions via the `RtmClient`:
```Unable to deserialize slack message, error: Json Error: ErrorImpl { code: Message("missing field `message`")```
Removing `message` fixes it. I also added a test to slack-rs, PR coming in a few minutes.