### PR TITLE
Proposed fix for dealing with inconsistently typed ts fields

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1,24 +1,17 @@
 use std::collections::HashMap;
 
-use std::{cmp, fmt};
+use std::fmt;
 
 use serde::de::{Visitor, Error, Unexpected, Deserializer};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct Timestamp {
-    string_repr: String,
-    float_repr: f64,
+    repr: f32,
 }
 
-impl cmp::PartialEq for Timestamp {
-    fn eq(&self, other: &Timestamp) -> bool {
-        self.float_repr.eq(&other.float_repr)
-    }
-}
-
-impl cmp::PartialOrd for Timestamp {
-    fn partial_cmp(&self, other: &Timestamp) -> Option<cmp::Ordering> {
-        self.float_repr.partial_cmp(&other.float_repr)
+impl fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.repr)
     }
 }
 
@@ -34,22 +27,19 @@ pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Tim
 
         fn visit_f64<E: Error>(self, v: f64) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
-                string_repr: v.to_string(),
-                float_repr: v,
+                repr: v as f32,
             }))
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
-                string_repr: v.to_string(),
-                float_repr: v.parse::<f64>().map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?
+                repr: v.parse::<f32>().map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?
             }))
         }
 	    
         fn visit_u64<E: Error>(self, v: u64) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
-                string_repr: (v as f64).to_string(),
-                float_repr: v as f64,
+                repr: v as f32,
             }))
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,18 +8,18 @@ use serde::de::{Visitor, Error, Unexpected};
 #[derive(Clone, Debug)]
 pub struct Timestamp {
     string_repr: String,
-    f32_repr: f32,
+    float_repr: f64,
 }
 
 impl cmp::PartialEq for Timestamp {
     fn eq(&self, other: &Timestamp) -> bool {
-        self.f32_repr.eq(&other.f32_repr)
+        self.float_repr.eq(&other.float_repr)
     }
 }
 
 impl cmp::PartialOrd for Timestamp {
     fn partial_cmp(&self, other: &Timestamp) -> Option<cmp::Ordering> {
-        self.f32_repr.partial_cmp(&other.f32_repr)
+        self.float_repr.partial_cmp(&other.float_repr)
     }
 }
 
@@ -30,23 +30,31 @@ pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Tim
 		type Value = Option<Timestamp>;
 
 		fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-			write!(fmt, "an f32 or parseable string")
+			write!(fmt, "an f64, u32, or parseable string")
 		}
 
-		fn visit_f32<E: Error>(self, v: f32) -> Result<Option<Timestamp>, E> {
+		fn visit_f64<E: Error>(self, v: f64) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
                 string_repr: v.to_string(),
-                f32_repr: v,
+                float_repr: v,
             }))
         }
 
 		fn visit_str<E: Error>(self, v: &str) -> Result<Option<Timestamp>, E> {
 		    Ok(Some(Timestamp {
                 string_repr: v.to_string(),
-                f32_repr: v.parse::<f32>().map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?
+                float_repr: v.parse::<f64>().map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?
             }))
         }
-	}
+	    
+        fn visit_u32<E: Error>(self, v: u32) -> Result<Option<Timestamp>, E> {
+            Ok(Some(Timestamp {
+                string_repr: f64::from(v).to_string(),
+                float_repr: f64::from(v),
+            }))
+        }
+    
+    }
 
 	d.deserialize_any(TimestampVisitor)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -910,7 +910,6 @@ pub struct MessageStandardAttachment {
     pub title: Option<String>,
     pub title_link: Option<String>,
     #[serde(deserialize_with = "deserialize_timestamp")]
-    #[serde(default)]
     pub ts: Option<Timestamp>,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -220,6 +220,8 @@ pub struct Im {
 pub enum Message {
     Standard(MessageStandard),
     BotMessage(MessageBotMessage),
+    //BotAdd(MessageBotAdd),
+    //BotRemove(MessageBotRemove), // TODO: I aasume this must be here, but I've never actually seen one
     ChannelArchive(MessageChannelArchive),
     ChannelJoin(MessageChannelJoin),
     ChannelLeave(MessageChannelLeave),
@@ -256,6 +258,8 @@ impl<'de> ::serde::Deserialize<'de> for Message {
         const VARIANTS: &'static [&'static str] = &[
             "standard",
             "bot_message",
+            //"bot_add",
+            //"bot_remove",
             "channel_archive",
             "channel_join",
             "channel_leave",
@@ -280,7 +284,7 @@ impl<'de> ::serde::Deserialize<'de> for Message {
             "pinned_item",
             "reply_broadcast",
             "unpinned_item",
-        ];
+       ];
 
         let value = ::serde_json::Value::deserialize(deserializer)?;
         if let Some(ty_val) = value.get("subtype") {
@@ -416,7 +420,7 @@ impl<'de> ::serde::Deserialize<'de> for Message {
                             .map(Message::UnpinnedItem)
                             .map_err(|e| D::Error::custom(&format!("{}", e)))
                     }
-                    _ => Err(D::Error::unknown_variant(ty, VARIANTS)),
+                   _ => Err(D::Error::unknown_variant(ty, VARIANTS)),
                 }
             } else {
                 Err(D::Error::invalid_type(
@@ -948,7 +952,6 @@ pub struct MessageUnpinnedItem {
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageUnpinnedItemItem {}
 
-#[derive(Clone, Debug, Deserialize)]
 pub struct Mpim {
     pub created: Option<i32>,
     pub creator: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,12 +25,12 @@ impl cmp::PartialOrd for Timestamp {
 
 /// Deserialize a maybe-string timestamp into a Timestamp.
 pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Timestamp>, D::Error> {
-	struct TimestampVisitor;
+    struct TimestampVisitor;
 	impl<'d> Visitor<'d> for TimestampVisitor {
 		type Value = Option<Timestamp>;
 
 		fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-			write!(fmt, "an f64, u32, or parseable string")
+			write!(fmt, "an f64, u64, or parseable string")
 		}
 
 		fn visit_f64<E: Error>(self, v: f64) -> Result<Option<Timestamp>, E> {
@@ -47,10 +47,10 @@ pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Tim
             }))
         }
 	    
-        fn visit_u32<E: Error>(self, v: u32) -> Result<Option<Timestamp>, E> {
+        fn visit_u64<E: Error>(self, v: u64) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
-                string_repr: f64::from(v).to_string(),
-                float_repr: f64::from(v),
+                string_repr: (v as f64).to_string(),
+                float_repr: v as f64,
             }))
         }
     

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,7 +28,7 @@ pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Tim
 	impl<'d> Visitor<'d> for TimestampVisitor {
         type Value = Option<Timestamp>;
 
-		fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
             write!(fmt, "an f64, u64, or parseable string")
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
-use std::fmt;
-use std::cmp;
-use serde::*;
-use serde::de::{Visitor, Error, Unexpected};
+use std::{cmp, fmt};
+
+use serde::de::{Visitor, Error, Unexpected, Deserializer};
 
 #[derive(Clone, Debug)]
 pub struct Timestamp {
@@ -27,21 +26,21 @@ impl cmp::PartialOrd for Timestamp {
 pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Timestamp>, D::Error> {
     struct TimestampVisitor;
 	impl<'d> Visitor<'d> for TimestampVisitor {
-		type Value = Option<Timestamp>;
+        type Value = Option<Timestamp>;
 
 		fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-			write!(fmt, "an f64, u64, or parseable string")
-		}
+            write!(fmt, "an f64, u64, or parseable string")
+        }
 
-		fn visit_f64<E: Error>(self, v: f64) -> Result<Option<Timestamp>, E> {
+        fn visit_f64<E: Error>(self, v: f64) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
                 string_repr: v.to_string(),
                 float_repr: v,
             }))
         }
 
-		fn visit_str<E: Error>(self, v: &str) -> Result<Option<Timestamp>, E> {
-		    Ok(Some(Timestamp {
+        fn visit_str<E: Error>(self, v: &str) -> Result<Option<Timestamp>, E> {
+            Ok(Some(Timestamp {
                 string_repr: v.to_string(),
                 float_repr: v.parse::<f64>().map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?
             }))
@@ -53,12 +52,10 @@ pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Tim
                 float_repr: v as f64,
             }))
         }
-    
     }
 
-	d.deserialize_any(TimestampVisitor)
+    d.deserialize_any(TimestampVisitor)
 }
-
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Bot {

--- a/src/types.rs
+++ b/src/types.rs
@@ -910,6 +910,7 @@ pub struct MessageStandardAttachment {
     pub title: Option<String>,
     pub title_link: Option<String>,
     #[serde(deserialize_with = "deserialize_timestamp")]
+    #[serde(default)]
     pub ts: Option<Timestamp>,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -215,8 +215,6 @@ pub struct Im {
 pub enum Message {
     Standard(MessageStandard),
     BotMessage(MessageBotMessage),
-    //BotAdd(MessageBotAdd),
-    //BotRemove(MessageBotRemove), // TODO: I aasume this must be here, but I've never actually seen one
     ChannelArchive(MessageChannelArchive),
     ChannelJoin(MessageChannelJoin),
     ChannelLeave(MessageChannelLeave),

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@ use serde::de::{Visitor, Error, Unexpected, Deserializer};
 
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub struct Timestamp {
-    repr: f32,
+    repr: f64,
 }
 
 impl fmt::Display for Timestamp {
@@ -25,19 +25,19 @@ pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Tim
 
         fn visit_f64<E: Error>(self, v: f64) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
-                repr: v as f32,
+                repr: v,
             }))
         }
 
         fn visit_str<E: Error>(self, v: &str) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
-                repr: v.parse::<f32>().map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?
+                repr: v.parse::<f64>().map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?
             }))
         }
 	    
         fn visit_u64<E: Error>(self, v: u64) -> Result<Option<Timestamp>, E> {
             Ok(Some(Timestamp {
-                repr: v as f32,
+                repr: v as f64,
             }))
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,57 @@
 use std::collections::HashMap;
 
+use std::fmt;
+use std::cmp;
+use serde::*;
+use serde::de::{Visitor, Error, Unexpected};
+
+#[derive(Clone, Debug)]
+pub struct Timestamp {
+    string_repr: String,
+    f32_repr: f32,
+}
+
+impl cmp::PartialEq for Timestamp {
+    fn eq(&self, other: &Timestamp) -> bool {
+        self.f32_repr.eq(&other.f32_repr)
+    }
+}
+
+impl cmp::PartialOrd for Timestamp {
+    fn partial_cmp(&self, other: &Timestamp) -> Option<cmp::Ordering> {
+        self.f32_repr.partial_cmp(&other.f32_repr)
+    }
+}
+
+/// Deserialize a maybe-string timestamp into a Timestamp.
+pub fn deserialize_timestamp<'d, D: Deserializer<'d>>(d: D) -> Result<Option<Timestamp>, D::Error> {
+	struct TimestampVisitor;
+	impl<'d> Visitor<'d> for TimestampVisitor {
+		type Value = Option<Timestamp>;
+
+		fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+			write!(fmt, "an f32 or parseable string")
+		}
+
+		fn visit_f32<E: Error>(self, v: f32) -> Result<Option<Timestamp>, E> {
+            Ok(Some(Timestamp {
+                string_repr: v.to_string(),
+                f32_repr: v,
+            }))
+        }
+
+		fn visit_str<E: Error>(self, v: &str) -> Result<Option<Timestamp>, E> {
+		    Ok(Some(Timestamp {
+                string_repr: v.to_string(),
+                f32_repr: v.parse::<f32>().map_err(|_| E::invalid_value(Unexpected::Str(v), &self))?
+            }))
+        }
+	}
+
+	d.deserialize_any(TimestampVisitor)
+}
+
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Bot {
     pub app_id: Option<String>,
@@ -860,7 +912,9 @@ pub struct MessageStandardAttachment {
     pub thumb_url: Option<String>,
     pub title: Option<String>,
     pub title_link: Option<String>,
-    pub ts: Option<f32>,
+    #[serde(deserialize_with = "deserialize_timestamp")]
+    #[serde(default)]
+    pub ts: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -254,8 +254,6 @@ pub enum Message {
     PinnedItem(MessagePinnedItem),
     ReplyBroadcast(MessageReplyBroadcast),
     UnpinnedItem(MessageUnpinnedItem),
-    SlackbotResponse(MessageSlackbotResponse),
-    ThreadBroadcast(MessageThreadBroadcast),
 }
 
 impl<'de> ::serde::Deserialize<'de> for Message {
@@ -268,8 +266,6 @@ impl<'de> ::serde::Deserialize<'de> for Message {
         const VARIANTS: &'static [&'static str] = &[
             "standard",
             "bot_message",
-            //"bot_add",
-            //"bot_remove",
             "channel_archive",
             "channel_join",
             "channel_leave",
@@ -430,7 +426,8 @@ impl<'de> ::serde::Deserialize<'de> for Message {
                             .map(Message::UnpinnedItem)
                             .map_err(|e| D::Error::custom(&format!("{}", e)))
                     }
-               }
+                    _ => Err(D::Error::unknown_variant(ty, VARIANTS)),
+                }
             } else {
                 Err(D::Error::invalid_type(
                     ::serde::de::Unexpected::Unit,
@@ -961,6 +958,7 @@ pub struct MessageUnpinnedItem {
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageUnpinnedItemItem {}
 
+#[derive(Clone, Debug, Deserialize)]
 pub struct Mpim {
     pub created: Option<i32>,
     pub creator: Option<String>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
-
 use std::fmt;
-
 use serde::de::{Visitor, Error, Unexpected, Deserializer};
 
 #[derive(Clone, Debug, PartialEq, PartialOrd)]


### PR DESCRIPTION
I've been exercising slack-rs-api a rather lot with [my messaging client](https://github.com/saethlin/omnichat), and I've run into a few issues. This is one; I previously just stubbed out the field but now I'm at a point where I want to use Slack's timestamps so I'd like to have some feedback on how to deal with them better. In most of this project they're `Option<String>`, but in a few they are/were `Option<f32>`, because Slack is inconsistent. I'd like to offer a sane wrapper over that via these changes, and possibly using this type for all instances of the `ts` field.

This will result in breakage, so it might be best to bundle with some other changes that I should have coming soon.

Oh dear I just realized that my slackbot response changes snuck in there. I'm rather new to git, so not quite sure what to do here :/