### PR TITLE
Changed `Channel.priority` from `i32` to `f64`.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -40,7 +40,7 @@ pub struct Channel {
     pub name_normalized: Option<String>,
     pub num_members: Option<i32>,
     pub previous_names: Option<Vec<String>>,
-    pub priority: Option<i32>,
+    pub priority: Option<f64>,
     pub purpose: Option<ChannelPurpose>,
     pub topic: Option<ChannelTopic>,
     pub unlinked: Option<i32>,


### PR DESCRIPTION
The `priority` field which is described in the `Channel` struct, is
wrong. It says it is an `i32`, and most of the time Slack will return 0.
Which works.

Sometimes Slack will return a floating point number. When this happens
Serde fails.

This commit changes the type to `f64`.