### PR TITLE
Remove ListResponseItemMessage::message

### DIFF
--- a/src/mods/reactions.rs
+++ b/src/mods/reactions.rs
@@ -661,7 +661,6 @@ pub struct ListResponseItemFileComment {
 #[derive(Clone, Debug, Deserialize)]
 pub struct ListResponseItemMessage {
     pub channel: String,
-    pub message: ::Message,
     #[serde(rename = "type")]
     pub ty: String,
 }


### PR DESCRIPTION
The [reaction_added] and [reaction_removed] events don't have
`message` as a field, which was causing the deserialization to fail,
preventing upstream libraries from handling reactions.

fixes slack-rs/slack-rs#111

[reaction_added]: https://api.slack.com/events/reaction_added
[reaction_removed]: https://api.slack.com/events/reaction_removed