### PR TITLE
allow swapping out openssl for rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0"
 
 [dependencies.reqwest]
 optional = true
-version = "^0.9"
+version = "0.9.6"
 default-features = false
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ serde_json = "1.0"
 [dependencies.reqwest]
 optional = true
 version = "^0.9"
+default-features = false
 
 [features]
-default = ["reqwest"]
+default = ["reqwest", "with_native_tls"]
+with_rustls = ["reqwest/rustls-tls"]
+with_native_tls = ["reqwest/default-tls"]


### PR DESCRIPTION
This is a pattern that is somewhat standard in other crates:

- [sentry](https://github.com/getsentry/sentry-rust/blob/002ee9775dcef28668685b273dd820126d688136/Cargo.toml#L37-L38)
- [github-rs](https://github.com/github-rs/github-rs/blob/a9861228dc41c601cec4481d56d170ae5d9d1e50/Cargo.toml#L12-L15)

But it only actively stops you from pulling in openssl if all crates let you customise this.