### PR TITLE
Upgrade reqwest dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,15 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 
-[dependencies.reqwest]
+[dependencies.reqwest_]
+package = "reqwest"
+version = "0.10.0"
 optional = true
-git = "https://github.com/seanmonstar/reqwest.git"
-branch = "release-0.10.0"
 default-features = false
+features = ["gzip"]
 
 [features]
-default = ["reqwest", "with_native_tls", "blocking"]
-with_rustls = ["reqwest/rustls-tls"]
-with_native_tls = ["reqwest/default-tls"]
-blocking = ["reqwest/blocking"]
+default = ["reqwest", "with_native_tls"]
+reqwest = ["reqwest_", "reqwest_/blocking"]
+with_rustls = ["reqwest_/rustls-tls"]
+with_native_tls = ["reqwest_/native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ documentation = "https://docs.rs/slack_api"
 license = "Apache-2.0"
 name = "slack_api"
 repository = "https://github.com/slack-rs/slack-rs-api.git"
-version = "0.21.0"
+version = "0.22.0-alpha.1"
 edition = "2018"
 
 [dependencies]
@@ -15,10 +15,12 @@ serde_json = "1.0"
 
 [dependencies.reqwest]
 optional = true
-version = "0.9.6"
+git = "https://github.com/seanmonstar/reqwest.git"
+branch = "release-0.10.0"
 default-features = false
 
 [features]
-default = ["reqwest", "with_native_tls"]
+default = ["reqwest", "with_native_tls", "blocking"]
 with_rustls = ["reqwest/rustls-tls"]
 with_native_tls = ["reqwest/default-tls"]
+blocking = ["reqwest/blocking"]

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -16,12 +16,12 @@ pub trait SlackWebRequestSender {
 
 #[cfg(feature = "reqwest")]
 mod reqwest_support {
+    pub use self::reqwest::Error;
     use reqwest;
-    pub use self::reqwest::{Client, Error};
 
     use super::SlackWebRequestSender;
 
-    impl SlackWebRequestSender for reqwest::Client {
+    impl SlackWebRequestSender for reqwest::blocking::Client {
         type Error = reqwest::Error;
 
         fn send(&self, method_url: &str, params: &[(&str, &str)]) -> Result<String, Self::Error> {
@@ -42,8 +42,8 @@ mod reqwest_support {
     /// let client = slack_api::requests::default_client().unwrap();
     /// let response = slack_api::channels::list(&client, &token, &Default::default());
     /// ```
-    pub fn default_client() -> Result<reqwest::Client, reqwest::Error> {
-        Ok(reqwest::Client::new())
+    pub fn default_client() -> Result<reqwest::blocking::Client, reqwest::Error> {
+        Ok(reqwest::blocking::Client::new())
     }
 }
 

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -16,8 +16,8 @@ pub trait SlackWebRequestSender {
 
 #[cfg(feature = "reqwest")]
 mod reqwest_support {
+    use reqwest_ as reqwest;
     pub use self::reqwest::Error;
-    use reqwest;
 
     use super::SlackWebRequestSender;
 


### PR DESCRIPTION
The [default reqwest client] in newer versions of reqwest have
asynchronous behavior.

Solution: Since blocking behavior is assumed by the rest of this
crate, it's simplest to use [reqwest's blocking client].

[default reqwest client]: https://github.com/seanmonstar/reqwest/blob/release-0.10.0/src/lib.rs#L278-L280
[reqwest's blocking client]: https://github.com/seanmonstar/reqwest/blob/release-0.10.0/src/lib.rs#L287-L288