### PR TITLE
Timestamp type

### DIFF
--- a/codegen/src/generator.rs
+++ b/codegen/src/generator.rs
@@ -442,6 +442,8 @@ impl Param {
 
     pub fn lifted(&self) -> Option<String> {
         match (&self.ty[..], self.optional) {
+            ("timestamp", true) => Some(format!("let {name} = request.{name}.as_ref().map(|t| t.to_param_value());", name = self.name)),
+            ("timestamp", false) => Some(format!("let {name} = request.{name}.to_param_value();", name = self.name)),
             ("integer", true) => Some(format!("let {name} = request.{name}.map(|{name}| {name}.to_string());", name = self.name)),
             ("integer", false) => Some(format!("let {name} = request.{name}.to_string();", name = self.name)),
             _ => None
@@ -464,6 +466,14 @@ impl Param {
                 // lifted into local variable, using {name} instead of request.{name}
                 format!("Some((\"{name}\", &{name}[..]))", name = self.name)
             },
+            ("timestamp", true) => {
+                // lifted into local variable, using {name} instead of request.{name}
+                format!("{name}.as_ref().map(|{name}| (\"{name}\", &{name}[..]))", name = self.name)
+            },
+            ("timestamp", false) => {
+                // lifted into local variable, using {name} instead of request.{name}
+                format!("Some((\"{name}\", &{name}[..]))", name = self.name)
+            },
             (_, true) => {
                 format!("request.{name}.map(|{name}| (\"{name}\", {name}))", name = self.name)
             },
@@ -475,6 +485,7 @@ impl Param {
 
     fn get_rust_type(&self) -> String {
         let ty = match &self.ty[..] {
+            "timestamp" => "crate::Timestamp",
             "boolean" => "bool",
             "integer" => "u32",
             _ => "&'a str",

--- a/codegen/src/generator.rs
+++ b/codegen/src/generator.rs
@@ -542,6 +542,10 @@ impl JsonEnumVariant {
 
 impl JsonEnum {
     pub fn to_code(&self) -> String {
+        if self.name == "Timestamp" {
+            return String::new()
+        }
+
         // Hack to work around message having a different identifier here
         let (variant_field, on_missing_field) = if self.name == "Message" {
             ("subtype", "::serde_json::from_value::<MessageStandard>(value.clone())

--- a/codegen/src/json_schema.rs
+++ b/codegen/src/json_schema.rs
@@ -91,7 +91,11 @@ impl PropType {
                     .map(|o| {
                         // TODO: Have this just check title. id is not reliable
                         let variant_name =
-                            o.title.as_ref().or_else(|| o.id.as_ref()).unwrap().to_pascal_case();
+                            o.title.as_ref()
+                                .or_else(|| o.id.as_ref())
+                                .or_else(|| o.ty.as_ref())
+                                .expect("variant name")
+                                .to_pascal_case();
                         let obj_name = name.to_owned() + &variant_name;
                         JsonEnumVariant {
                             name: variant_name.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ use serde;
 #[macro_use]
 extern crate serde_derive;
 
+mod timestamp;
+pub use crate::timestamp::*;
 
 mod mods;
 pub use crate::mods::*;
@@ -111,5 +113,10 @@ mod tests {
     fn test_user_profile_fields_undefined_deserialize() {
         let user_profile: UserProfile = serde_json::from_str(r#"{}"#).unwrap();
         assert!(user_profile.fields.is_none());
+    }
+
+    #[test]
+    fn test_timestamp_to_param_value() {
+        assert_eq!(crate::Timestamp::from(1234567.0).to_param_value(), "1234567.0");
     }
 }

--- a/src/mods/api.rs
+++ b/src/mods/api.rs
@@ -42,7 +42,7 @@ pub struct TestRequest<'a> {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct TestResponse {
-    pub args: Option<HashMap<String, bool>>,
+    pub args: Option<HashMap<String, String>>,
     error: Option<String>,
     #[serde(default)]
     ok: bool,

--- a/src/mods/auth.rs
+++ b/src/mods/auth.rs
@@ -33,7 +33,8 @@ where
         .send(&url, &params[..])
         .map_err(RevokeError::Client)
         .and_then(|result| {
-            serde_json::from_str::<RevokeResponse>(&result).map_err(RevokeError::MalformedResponse)
+            serde_json::from_str::<RevokeResponse>(&result)
+                .map_err(|e| RevokeError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -86,7 +87,7 @@ pub enum RevokeError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -132,7 +133,7 @@ RevokeError::InvalidPostType => "invalid_post_type: The method was called via a 
 RevokeError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RevokeError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RevokeError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RevokeError::MalformedResponse(ref e) => e.description(),
+                        RevokeError::MalformedResponse(_, ref e) => e.description(),
                         RevokeError::Unknown(ref s) => s,
                         RevokeError::Client(ref inner) => inner.description()
                     }
@@ -140,7 +141,7 @@ RevokeError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RevokeError::MalformedResponse(ref e) => Some(e),
+            RevokeError::MalformedResponse(_, ref e) => Some(e),
             RevokeError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -161,7 +162,8 @@ where
         .send(&url, &params[..])
         .map_err(TestError::Client)
         .and_then(|result| {
-            serde_json::from_str::<TestResponse>(&result).map_err(TestError::MalformedResponse)
+            serde_json::from_str::<TestResponse>(&result)
+                .map_err(|e| TestError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -212,7 +214,7 @@ pub enum TestError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -258,7 +260,7 @@ TestError::InvalidPostType => "invalid_post_type: The method was called via a PO
 TestError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 TestError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 TestError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        TestError::MalformedResponse(ref e) => e.description(),
+                        TestError::MalformedResponse(_, ref e) => e.description(),
                         TestError::Unknown(ref s) => s,
                         TestError::Client(ref inner) => inner.description()
                     }
@@ -266,7 +268,7 @@ TestError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            TestError::MalformedResponse(ref e) => Some(e),
+            TestError::MalformedResponse(_, ref e) => Some(e),
             TestError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/channels.rs
+++ b/src/mods/channels.rs
@@ -30,7 +30,7 @@ where
         .map_err(ArchiveError::Client)
         .and_then(|result| {
             serde_json::from_str::<ArchiveResponse>(&result)
-                .map_err(ArchiveError::MalformedResponse)
+                .map_err(|e| ArchiveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -94,7 +94,7 @@ pub enum ArchiveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -152,7 +152,7 @@ ArchiveError::InvalidPostType => "invalid_post_type: The method was called via a
 ArchiveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ArchiveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ArchiveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ArchiveError::MalformedResponse(ref e) => e.description(),
+                        ArchiveError::MalformedResponse(_, ref e) => e.description(),
                         ArchiveError::Unknown(ref s) => s,
                         ArchiveError::Client(ref inner) => inner.description()
                     }
@@ -160,7 +160,7 @@ ArchiveError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ArchiveError::MalformedResponse(ref e) => Some(e),
+            ArchiveError::MalformedResponse(_, ref e) => Some(e),
             ArchiveError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -192,7 +192,8 @@ where
         .send(&url, &params[..])
         .map_err(CreateError::Client)
         .and_then(|result| {
-            serde_json::from_str::<CreateResponse>(&result).map_err(CreateError::MalformedResponse)
+            serde_json::from_str::<CreateResponse>(&result)
+                .map_err(|e| CreateError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -267,7 +268,7 @@ pub enum CreateError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -333,7 +334,7 @@ CreateError::InvalidPostType => "invalid_post_type: The method was called via a 
 CreateError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 CreateError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 CreateError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        CreateError::MalformedResponse(ref e) => e.description(),
+                        CreateError::MalformedResponse(_, ref e) => e.description(),
                         CreateError::Unknown(ref s) => s,
                         CreateError::Client(ref inner) => inner.description()
                     }
@@ -341,7 +342,7 @@ CreateError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            CreateError::MalformedResponse(ref e) => Some(e),
+            CreateError::MalformedResponse(_, ref e) => Some(e),
             CreateError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -383,7 +384,7 @@ where
         .map_err(HistoryError::Client)
         .and_then(|result| {
             serde_json::from_str::<HistoryResponse>(&result)
-                .map_err(HistoryError::MalformedResponse)
+                .map_err(|e| HistoryError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -454,7 +455,7 @@ pub enum HistoryError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -506,7 +507,7 @@ HistoryError::InvalidPostType => "invalid_post_type: The method was called via a
 HistoryError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 HistoryError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 HistoryError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        HistoryError::MalformedResponse(ref e) => e.description(),
+                        HistoryError::MalformedResponse(_, ref e) => e.description(),
                         HistoryError::Unknown(ref s) => s,
                         HistoryError::Client(ref inner) => inner.description()
                     }
@@ -514,7 +515,7 @@ HistoryError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            HistoryError::MalformedResponse(ref e) => Some(e),
+            HistoryError::MalformedResponse(_, ref e) => Some(e),
             HistoryError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -540,7 +541,8 @@ where
         .send(&url, &params[..])
         .map_err(InfoError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InfoResponse>(&result).map_err(InfoError::MalformedResponse)
+            serde_json::from_str::<InfoResponse>(&result)
+                .map_err(|e| InfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -595,7 +597,7 @@ pub enum InfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -643,7 +645,7 @@ InfoError::InvalidPostType => "invalid_post_type: The method was called via a PO
 InfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InfoError::MalformedResponse(ref e) => e.description(),
+                        InfoError::MalformedResponse(_, ref e) => e.description(),
                         InfoError::Unknown(ref s) => s,
                         InfoError::Client(ref inner) => inner.description()
                     }
@@ -651,7 +653,7 @@ InfoError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InfoError::MalformedResponse(ref e) => Some(e),
+            InfoError::MalformedResponse(_, ref e) => Some(e),
             InfoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -681,7 +683,8 @@ where
         .send(&url, &params[..])
         .map_err(InviteError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InviteResponse>(&result).map_err(InviteError::MalformedResponse)
+            serde_json::from_str::<InviteResponse>(&result)
+                .map_err(|e| InviteError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -756,7 +759,7 @@ pub enum InviteError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -822,7 +825,7 @@ InviteError::InvalidPostType => "invalid_post_type: The method was called via a 
 InviteError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InviteError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InviteError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InviteError::MalformedResponse(ref e) => e.description(),
+                        InviteError::MalformedResponse(_, ref e) => e.description(),
                         InviteError::Unknown(ref s) => s,
                         InviteError::Client(ref inner) => inner.description()
                     }
@@ -830,7 +833,7 @@ InviteError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InviteError::MalformedResponse(ref e) => Some(e),
+            InviteError::MalformedResponse(_, ref e) => Some(e),
             InviteError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -862,7 +865,8 @@ where
         .send(&url, &params[..])
         .map_err(JoinError::Client)
         .and_then(|result| {
-            serde_json::from_str::<JoinResponse>(&result).map_err(JoinError::MalformedResponse)
+            serde_json::from_str::<JoinResponse>(&result)
+                .map_err(|e| JoinError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -941,7 +945,7 @@ pub enum JoinError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1011,7 +1015,7 @@ JoinError::InvalidPostType => "invalid_post_type: The method was called via a PO
 JoinError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 JoinError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 JoinError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        JoinError::MalformedResponse(ref e) => e.description(),
+                        JoinError::MalformedResponse(_, ref e) => e.description(),
                         JoinError::Unknown(ref s) => s,
                         JoinError::Client(ref inner) => inner.description()
                     }
@@ -1019,7 +1023,7 @@ JoinError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            JoinError::MalformedResponse(ref e) => Some(e),
+            JoinError::MalformedResponse(_, ref e) => Some(e),
             JoinError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1049,7 +1053,8 @@ where
         .send(&url, &params[..])
         .map_err(KickError::Client)
         .and_then(|result| {
-            serde_json::from_str::<KickResponse>(&result).map_err(KickError::MalformedResponse)
+            serde_json::from_str::<KickResponse>(&result)
+                .map_err(|e| KickError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1119,7 +1124,7 @@ pub enum KickError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1181,7 +1186,7 @@ KickError::InvalidPostType => "invalid_post_type: The method was called via a PO
 KickError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 KickError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 KickError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        KickError::MalformedResponse(ref e) => e.description(),
+                        KickError::MalformedResponse(_, ref e) => e.description(),
                         KickError::Unknown(ref s) => s,
                         KickError::Client(ref inner) => inner.description()
                     }
@@ -1189,7 +1194,7 @@ KickError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            KickError::MalformedResponse(ref e) => Some(e),
+            KickError::MalformedResponse(_, ref e) => Some(e),
             KickError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1215,7 +1220,8 @@ where
         .send(&url, &params[..])
         .map_err(LeaveError::Client)
         .and_then(|result| {
-            serde_json::from_str::<LeaveResponse>(&result).map_err(LeaveError::MalformedResponse)
+            serde_json::from_str::<LeaveResponse>(&result)
+                .map_err(|e| LeaveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1277,7 +1283,7 @@ pub enum LeaveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1333,7 +1339,7 @@ LeaveError::InvalidPostType => "invalid_post_type: The method was called via a P
 LeaveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 LeaveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 LeaveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        LeaveError::MalformedResponse(ref e) => e.description(),
+                        LeaveError::MalformedResponse(_, ref e) => e.description(),
                         LeaveError::Unknown(ref s) => s,
                         LeaveError::Client(ref inner) => inner.description()
                     }
@@ -1341,7 +1347,7 @@ LeaveError::RequestTimeout => "request_timeout: The method was called via a POST
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            LeaveError::MalformedResponse(ref e) => Some(e),
+            LeaveError::MalformedResponse(_, ref e) => Some(e),
             LeaveError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1375,7 +1381,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1430,7 +1437,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1476,7 +1483,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -1484,7 +1491,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1515,7 +1522,8 @@ where
         .send(&url, &params[..])
         .map_err(MarkError::Client)
         .and_then(|result| {
-            serde_json::from_str::<MarkResponse>(&result).map_err(MarkError::MalformedResponse)
+            serde_json::from_str::<MarkResponse>(&result)
+                .map_err(|e| MarkError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1575,7 +1583,7 @@ pub enum MarkError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1627,7 +1635,7 @@ MarkError::InvalidPostType => "invalid_post_type: The method was called via a PO
 MarkError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 MarkError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 MarkError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        MarkError::MalformedResponse(ref e) => e.description(),
+                        MarkError::MalformedResponse(_, ref e) => e.description(),
                         MarkError::Unknown(ref s) => s,
                         MarkError::Client(ref inner) => inner.description()
                     }
@@ -1635,7 +1643,7 @@ MarkError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            MarkError::MalformedResponse(ref e) => Some(e),
+            MarkError::MalformedResponse(_, ref e) => Some(e),
             MarkError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1668,7 +1676,8 @@ where
         .send(&url, &params[..])
         .map_err(RenameError::Client)
         .and_then(|result| {
-            serde_json::from_str::<RenameResponse>(&result).map_err(RenameError::MalformedResponse)
+            serde_json::from_str::<RenameResponse>(&result)
+                .map_err(|e| RenameError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1755,7 +1764,7 @@ pub enum RenameError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1823,7 +1832,7 @@ RenameError::InvalidPostType => "invalid_post_type: The method was called via a 
 RenameError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RenameError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RenameError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RenameError::MalformedResponse(ref e) => e.description(),
+                        RenameError::MalformedResponse(_, ref e) => e.description(),
                         RenameError::Unknown(ref s) => s,
                         RenameError::Client(ref inner) => inner.description()
                     }
@@ -1831,7 +1840,7 @@ RenameError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RenameError::MalformedResponse(ref e) => Some(e),
+            RenameError::MalformedResponse(_, ref e) => Some(e),
             RenameError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1863,7 +1872,7 @@ where
         .map_err(RepliesError::Client)
         .and_then(|result| {
             serde_json::from_str::<RepliesResponse>(&result)
-                .map_err(RepliesError::MalformedResponse)
+                .map_err(|e| RepliesError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1923,7 +1932,7 @@ pub enum RepliesError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1973,7 +1982,7 @@ RepliesError::InvalidPostType => "invalid_post_type: The method was called via a
 RepliesError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RepliesError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RepliesError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RepliesError::MalformedResponse(ref e) => e.description(),
+                        RepliesError::MalformedResponse(_, ref e) => e.description(),
                         RepliesError::Unknown(ref s) => s,
                         RepliesError::Client(ref inner) => inner.description()
                     }
@@ -1981,7 +1990,7 @@ RepliesError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RepliesError::MalformedResponse(ref e) => Some(e),
+            RepliesError::MalformedResponse(_, ref e) => Some(e),
             RepliesError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -2012,7 +2021,7 @@ where
         .map_err(SetPurposeError::Client)
         .and_then(|result| {
             serde_json::from_str::<SetPurposeResponse>(&result)
-                .map_err(SetPurposeError::MalformedResponse)
+                .map_err(|e| SetPurposeError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -2077,7 +2086,7 @@ pub enum SetPurposeError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -2133,7 +2142,7 @@ SetPurposeError::InvalidPostType => "invalid_post_type: The method was called vi
 SetPurposeError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SetPurposeError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SetPurposeError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SetPurposeError::MalformedResponse(ref e) => e.description(),
+                        SetPurposeError::MalformedResponse(_, ref e) => e.description(),
                         SetPurposeError::Unknown(ref s) => s,
                         SetPurposeError::Client(ref inner) => inner.description()
                     }
@@ -2141,7 +2150,7 @@ SetPurposeError::RequestTimeout => "request_timeout: The method was called via a
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SetPurposeError::MalformedResponse(ref e) => Some(e),
+            SetPurposeError::MalformedResponse(_, ref e) => Some(e),
             SetPurposeError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -2172,7 +2181,7 @@ where
         .map_err(SetTopicError::Client)
         .and_then(|result| {
             serde_json::from_str::<SetTopicResponse>(&result)
-                .map_err(SetTopicError::MalformedResponse)
+                .map_err(|e| SetTopicError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -2237,7 +2246,7 @@ pub enum SetTopicError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -2293,7 +2302,7 @@ SetTopicError::InvalidPostType => "invalid_post_type: The method was called via 
 SetTopicError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SetTopicError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SetTopicError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SetTopicError::MalformedResponse(ref e) => e.description(),
+                        SetTopicError::MalformedResponse(_, ref e) => e.description(),
                         SetTopicError::Unknown(ref s) => s,
                         SetTopicError::Client(ref inner) => inner.description()
                     }
@@ -2301,7 +2310,7 @@ SetTopicError::RequestTimeout => "request_timeout: The method was called via a P
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SetTopicError::MalformedResponse(ref e) => Some(e),
+            SetTopicError::MalformedResponse(_, ref e) => Some(e),
             SetTopicError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -2328,7 +2337,7 @@ where
         .map_err(UnarchiveError::Client)
         .and_then(|result| {
             serde_json::from_str::<UnarchiveResponse>(&result)
-                .map_err(UnarchiveError::MalformedResponse)
+                .map_err(|e| UnarchiveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -2388,7 +2397,7 @@ pub enum UnarchiveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -2442,7 +2451,7 @@ UnarchiveError::InvalidPostType => "invalid_post_type: The method was called via
 UnarchiveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 UnarchiveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 UnarchiveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        UnarchiveError::MalformedResponse(ref e) => e.description(),
+                        UnarchiveError::MalformedResponse(_, ref e) => e.description(),
                         UnarchiveError::Unknown(ref s) => s,
                         UnarchiveError::Client(ref inner) => inner.description()
                     }
@@ -2450,7 +2459,7 @@ UnarchiveError::RequestTimeout => "request_timeout: The method was called via a 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            UnarchiveError::MalformedResponse(ref e) => Some(e),
+            UnarchiveError::MalformedResponse(_, ref e) => Some(e),
             UnarchiveError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/channels.rs
+++ b/src/mods/channels.rs
@@ -360,12 +360,14 @@ pub fn history<R>(
 where
     R: SlackWebRequestSender,
 {
+    let latest = request.latest.as_ref().map(|t| t.to_param_value());
+    let oldest = request.oldest.as_ref().map(|t| t.to_param_value());
     let count = request.count.map(|count| count.to_string());
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        request.latest.map(|latest| ("latest", latest)),
-        request.oldest.map(|oldest| ("oldest", oldest)),
+        latest.as_ref().map(|latest| ("latest", &latest[..])),
+        oldest.as_ref().map(|oldest| ("oldest", &oldest[..])),
         request
             .inclusive
             .map(|inclusive| ("inclusive", if inclusive { "1" } else { "0" })),
@@ -391,9 +393,9 @@ pub struct HistoryRequest<'a> {
     /// Channel to fetch history for.
     pub channel: &'a str,
     /// End of time range of messages to include in results.
-    pub latest: Option<&'a str>,
+    pub latest: Option<crate::Timestamp>,
     /// Start of time range of messages to include in results.
-    pub oldest: Option<&'a str>,
+    pub oldest: Option<crate::Timestamp>,
     /// Include messages with latest or oldest timestamp in results.
     pub inclusive: Option<bool>,
     /// Number of messages to return, between 1 and 1000.
@@ -1501,10 +1503,11 @@ pub fn mark<R>(
 where
     R: SlackWebRequestSender,
 {
+    let ts = request.ts.to_param_value();
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        Some(("ts", request.ts)),
+        Some(("ts", &ts[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("channels.mark");
@@ -1522,7 +1525,7 @@ pub struct MarkRequest<'a> {
     /// Channel to set reading cursor in.
     pub channel: &'a str,
     /// Timestamp of the most recently seen message.
-    pub ts: &'a str,
+    pub ts: crate::Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1847,10 +1850,11 @@ pub fn replies<R>(
 where
     R: SlackWebRequestSender,
 {
+    let thread_ts = request.thread_ts.to_param_value();
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        Some(("thread_ts", request.thread_ts)),
+        Some(("thread_ts", &thread_ts[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("channels.replies");
@@ -1869,7 +1873,7 @@ pub struct RepliesRequest<'a> {
     /// Channel to fetch thread from
     pub channel: &'a str,
     /// Unique identifier of a thread's parent message
-    pub thread_ts: &'a str,
+    pub thread_ts: crate::Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/mods/chat.rs
+++ b/src/mods/chat.rs
@@ -22,9 +22,10 @@ pub fn delete<R>(
 where
     R: SlackWebRequestSender,
 {
+    let ts = request.ts.to_param_value();
     let params = vec![
         Some(("token", token)),
-        Some(("ts", request.ts)),
+        Some(("ts", &ts[..])),
         Some(("channel", request.channel)),
         request
             .as_user
@@ -44,7 +45,7 @@ where
 #[derive(Clone, Default, Debug)]
 pub struct DeleteRequest<'a> {
     /// Timestamp of the message to be deleted.
-    pub ts: &'a str,
+    pub ts: crate::Timestamp,
     /// Channel containing the message to be deleted.
     pub channel: &'a str,
     /// Pass true to delete the message as the authed user. Bot users in this context are considered authed users.
@@ -348,6 +349,7 @@ pub fn post_message<R>(
 where
     R: SlackWebRequestSender,
 {
+    let thread_ts = request.thread_ts.as_ref().map(|t| t.to_param_value());
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
@@ -373,7 +375,9 @@ where
         request
             .icon_emoji
             .map(|icon_emoji| ("icon_emoji", icon_emoji)),
-        request.thread_ts.map(|thread_ts| ("thread_ts", thread_ts)),
+        thread_ts
+            .as_ref()
+            .map(|thread_ts| ("thread_ts", &thread_ts[..])),
         request
             .reply_broadcast
             .map(|reply_broadcast| ("reply_broadcast", if reply_broadcast { "1" } else { "0" })),
@@ -415,7 +419,7 @@ pub struct PostMessageRequest<'a> {
     /// Emoji to use as the icon for this message. Overrides icon_url. Must be used in conjunction with as_user set to false, otherwise ignored. See authorship below.
     pub icon_emoji: Option<&'a str>,
     /// Provide another message's ts value to make this message a reply. Avoid using a reply's ts value; use its parent instead.
-    pub thread_ts: Option<&'a str>,
+    pub thread_ts: Option<crate::Timestamp>,
     /// Used in conjunction with thread_ts and indicates whether reply should be made visible to everyone in the channel or conversation. Defaults to false.
     pub reply_broadcast: Option<bool>,
 }
@@ -718,9 +722,10 @@ pub fn update<R>(
 where
     R: SlackWebRequestSender,
 {
+    let ts = request.ts.to_param_value();
     let params = vec![
         Some(("token", token)),
-        Some(("ts", request.ts)),
+        Some(("ts", &ts[..])),
         Some(("channel", request.channel)),
         Some(("text", request.text)),
         request
@@ -748,7 +753,7 @@ where
 #[derive(Clone, Default, Debug)]
 pub struct UpdateRequest<'a> {
     /// Timestamp of the message to be updated.
-    pub ts: &'a str,
+    pub ts: crate::Timestamp,
     /// Channel containing the message to be updated.
     pub channel: &'a str,
     /// New text for the message, using the default formatting rules.

--- a/src/mods/chat.rs
+++ b/src/mods/chat.rs
@@ -37,7 +37,8 @@ where
         .send(&url, &params[..])
         .map_err(DeleteError::Client)
         .and_then(|result| {
-            serde_json::from_str::<DeleteResponse>(&result).map_err(DeleteError::MalformedResponse)
+            serde_json::from_str::<DeleteResponse>(&result)
+                .map_err(|e| DeleteError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -103,7 +104,7 @@ pub enum DeleteError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -157,7 +158,7 @@ DeleteError::InvalidPostType => "invalid_post_type: The method was called via a 
 DeleteError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 DeleteError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 DeleteError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        DeleteError::MalformedResponse(ref e) => e.description(),
+                        DeleteError::MalformedResponse(_, ref e) => e.description(),
                         DeleteError::Unknown(ref s) => s,
                         DeleteError::Client(ref inner) => inner.description()
                     }
@@ -165,7 +166,7 @@ DeleteError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            DeleteError::MalformedResponse(ref e) => Some(e),
+            DeleteError::MalformedResponse(_, ref e) => Some(e),
             DeleteError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -196,7 +197,7 @@ where
         .map_err(MeMessageError::Client)
         .and_then(|result| {
             serde_json::from_str::<MeMessageResponse>(&result)
-                .map_err(MeMessageError::MalformedResponse)
+                .map_err(|e| MeMessageError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -264,7 +265,7 @@ pub enum MeMessageError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -322,7 +323,7 @@ MeMessageError::InvalidPostType => "invalid_post_type: The method was called via
 MeMessageError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 MeMessageError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 MeMessageError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        MeMessageError::MalformedResponse(ref e) => e.description(),
+                        MeMessageError::MalformedResponse(_, ref e) => e.description(),
                         MeMessageError::Unknown(ref s) => s,
                         MeMessageError::Client(ref inner) => inner.description()
                     }
@@ -330,7 +331,7 @@ MeMessageError::RequestTimeout => "request_timeout: The method was called via a 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            MeMessageError::MalformedResponse(ref e) => Some(e),
+            MeMessageError::MalformedResponse(_, ref e) => Some(e),
             MeMessageError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -389,7 +390,7 @@ where
         .map_err(PostMessageError::Client)
         .and_then(|result| {
             serde_json::from_str::<PostMessageResponse>(&result)
-                .map_err(PostMessageError::MalformedResponse)
+                .map_err(|e| PostMessageError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -482,7 +483,7 @@ pub enum PostMessageError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -542,7 +543,7 @@ PostMessageError::InvalidPostType => "invalid_post_type: The method was called v
 PostMessageError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 PostMessageError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 PostMessageError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        PostMessageError::MalformedResponse(ref e) => e.description(),
+                        PostMessageError::MalformedResponse(_, ref e) => e.description(),
                         PostMessageError::Unknown(ref s) => s,
                         PostMessageError::Client(ref inner) => inner.description()
                     }
@@ -550,7 +551,7 @@ PostMessageError::RequestTimeout => "request_timeout: The method was called via 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            PostMessageError::MalformedResponse(ref e) => Some(e),
+            PostMessageError::MalformedResponse(_, ref e) => Some(e),
             PostMessageError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -587,7 +588,8 @@ where
         .send(&url, &params[..])
         .map_err(UnfurlError::Client)
         .and_then(|result| {
-            serde_json::from_str::<UnfurlResponse>(&result).map_err(UnfurlError::MalformedResponse)
+            serde_json::from_str::<UnfurlResponse>(&result)
+                .map_err(|e| UnfurlError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -647,7 +649,7 @@ pub enum UnfurlError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -695,7 +697,7 @@ UnfurlError::InvalidPostType => "invalid_post_type: The method was called via a 
 UnfurlError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 UnfurlError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 UnfurlError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        UnfurlError::MalformedResponse(ref e) => e.description(),
+                        UnfurlError::MalformedResponse(_, ref e) => e.description(),
                         UnfurlError::Unknown(ref s) => s,
                         UnfurlError::Client(ref inner) => inner.description()
                     }
@@ -703,7 +705,7 @@ UnfurlError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            UnfurlError::MalformedResponse(ref e) => Some(e),
+            UnfurlError::MalformedResponse(_, ref e) => Some(e),
             UnfurlError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -745,7 +747,8 @@ where
         .send(&url, &params[..])
         .map_err(UpdateError::Client)
         .and_then(|result| {
-            serde_json::from_str::<UpdateResponse>(&result).map_err(UpdateError::MalformedResponse)
+            serde_json::from_str::<UpdateResponse>(&result)
+                .map_err(|e| UpdateError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -826,7 +829,7 @@ pub enum UpdateError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -886,7 +889,7 @@ UpdateError::InvalidPostType => "invalid_post_type: The method was called via a 
 UpdateError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 UpdateError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 UpdateError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        UpdateError::MalformedResponse(ref e) => e.description(),
+                        UpdateError::MalformedResponse(_, ref e) => e.description(),
                         UpdateError::Unknown(ref s) => s,
                         UpdateError::Client(ref inner) => inner.description()
                     }
@@ -894,7 +897,7 @@ UpdateError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            UpdateError::MalformedResponse(ref e) => Some(e),
+            UpdateError::MalformedResponse(_, ref e) => Some(e),
             UpdateError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/dnd.rs
+++ b/src/mods/dnd.rs
@@ -164,8 +164,8 @@ where
 pub struct EndSnoozeResponse {
     pub dnd_enabled: Option<bool>,
     error: Option<String>,
-    pub next_dnd_end_ts: Option<f32>,
-    pub next_dnd_start_ts: Option<f32>,
+    pub next_dnd_end_ts: Option<crate::Timestamp>,
+    pub next_dnd_start_ts: Option<crate::Timestamp>,
     #[serde(default)]
     ok: bool,
     pub snooze_enabled: Option<bool>,
@@ -316,12 +316,12 @@ pub struct InfoRequest<'a> {
 pub struct InfoResponse {
     pub dnd_enabled: Option<bool>,
     error: Option<String>,
-    pub next_dnd_end_ts: Option<f32>,
-    pub next_dnd_start_ts: Option<f32>,
+    pub next_dnd_end_ts: Option<crate::Timestamp>,
+    pub next_dnd_start_ts: Option<crate::Timestamp>,
     #[serde(default)]
     ok: bool,
     pub snooze_enabled: Option<bool>,
-    pub snooze_endtime: Option<f32>,
+    pub snooze_endtime: Option<crate::Timestamp>,
     pub snooze_remaining: Option<f32>,
 }
 
@@ -465,7 +465,7 @@ pub struct SetSnoozeResponse {
     #[serde(default)]
     ok: bool,
     pub snooze_enabled: Option<bool>,
-    pub snooze_endtime: Option<f32>,
+    pub snooze_endtime: Option<crate::Timestamp>,
     pub snooze_remaining: Option<f32>,
 }
 

--- a/src/mods/dnd.rs
+++ b/src/mods/dnd.rs
@@ -24,7 +24,8 @@ where
         .send(&url, &params[..])
         .map_err(EndDndError::Client)
         .and_then(|result| {
-            serde_json::from_str::<EndDndResponse>(&result).map_err(EndDndError::MalformedResponse)
+            serde_json::from_str::<EndDndResponse>(&result)
+                .map_err(|e| EndDndError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -74,7 +75,7 @@ pub enum EndDndError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -124,7 +125,7 @@ EndDndError::InvalidPostType => "invalid_post_type: The method was called via a 
 EndDndError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 EndDndError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 EndDndError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        EndDndError::MalformedResponse(ref e) => e.description(),
+                        EndDndError::MalformedResponse(_, ref e) => e.description(),
                         EndDndError::Unknown(ref s) => s,
                         EndDndError::Client(ref inner) => inner.description()
                     }
@@ -132,7 +133,7 @@ EndDndError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            EndDndError::MalformedResponse(ref e) => Some(e),
+            EndDndError::MalformedResponse(_, ref e) => Some(e),
             EndDndError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -154,7 +155,7 @@ where
         .map_err(EndSnoozeError::Client)
         .and_then(|result| {
             serde_json::from_str::<EndSnoozeResponse>(&result)
-                .map_err(EndSnoozeError::MalformedResponse)
+                .map_err(|e| EndSnoozeError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -210,7 +211,7 @@ pub enum EndSnoozeError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -262,7 +263,7 @@ EndSnoozeError::InvalidPostType => "invalid_post_type: The method was called via
 EndSnoozeError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 EndSnoozeError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 EndSnoozeError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        EndSnoozeError::MalformedResponse(ref e) => e.description(),
+                        EndSnoozeError::MalformedResponse(_, ref e) => e.description(),
                         EndSnoozeError::Unknown(ref s) => s,
                         EndSnoozeError::Client(ref inner) => inner.description()
                     }
@@ -270,7 +271,7 @@ EndSnoozeError::RequestTimeout => "request_timeout: The method was called via a 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            EndSnoozeError::MalformedResponse(ref e) => Some(e),
+            EndSnoozeError::MalformedResponse(_, ref e) => Some(e),
             EndSnoozeError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -299,7 +300,8 @@ where
         .send(&url, &params[..])
         .map_err(InfoError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InfoResponse>(&result).map_err(InfoError::MalformedResponse)
+            serde_json::from_str::<InfoResponse>(&result)
+                .map_err(|e| InfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -359,7 +361,7 @@ pub enum InfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -407,7 +409,7 @@ InfoError::InvalidPostType => "invalid_post_type: The method was called via a PO
 InfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InfoError::MalformedResponse(ref e) => e.description(),
+                        InfoError::MalformedResponse(_, ref e) => e.description(),
                         InfoError::Unknown(ref s) => s,
                         InfoError::Client(ref inner) => inner.description()
                     }
@@ -415,7 +417,7 @@ InfoError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InfoError::MalformedResponse(ref e) => Some(e),
+            InfoError::MalformedResponse(_, ref e) => Some(e),
             InfoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -446,7 +448,7 @@ where
         .map_err(SetSnoozeError::Client)
         .and_then(|result| {
             serde_json::from_str::<SetSnoozeResponse>(&result)
-                .map_err(SetSnoozeError::MalformedResponse)
+                .map_err(|e| SetSnoozeError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -507,7 +509,7 @@ pub enum SetSnoozeError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -559,7 +561,7 @@ SetSnoozeError::InvalidPostType => "invalid_post_type: The method was called via
 SetSnoozeError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SetSnoozeError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SetSnoozeError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SetSnoozeError::MalformedResponse(ref e) => e.description(),
+                        SetSnoozeError::MalformedResponse(_, ref e) => e.description(),
                         SetSnoozeError::Unknown(ref s) => s,
                         SetSnoozeError::Client(ref inner) => inner.description()
                     }
@@ -567,7 +569,7 @@ SetSnoozeError::RequestTimeout => "request_timeout: The method was called via a 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SetSnoozeError::MalformedResponse(ref e) => Some(e),
+            SetSnoozeError::MalformedResponse(_, ref e) => Some(e),
             SetSnoozeError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -597,7 +599,7 @@ where
         .map_err(TeamInfoError::Client)
         .and_then(|result| {
             serde_json::from_str::<TeamInfoResponse>(&result)
-                .map_err(TeamInfoError::MalformedResponse)
+                .map_err(|e| TeamInfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -650,7 +652,7 @@ pub enum TeamInfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -696,7 +698,7 @@ TeamInfoError::InvalidPostType => "invalid_post_type: The method was called via 
 TeamInfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 TeamInfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 TeamInfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        TeamInfoError::MalformedResponse(ref e) => e.description(),
+                        TeamInfoError::MalformedResponse(_, ref e) => e.description(),
                         TeamInfoError::Unknown(ref s) => s,
                         TeamInfoError::Client(ref inner) => inner.description()
                     }
@@ -704,7 +706,7 @@ TeamInfoError::RequestTimeout => "request_timeout: The method was called via a P
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            TeamInfoError::MalformedResponse(ref e) => Some(e),
+            TeamInfoError::MalformedResponse(_, ref e) => Some(e),
             TeamInfoError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/files.rs
+++ b/src/mods/files.rs
@@ -29,7 +29,8 @@ where
         .send(&url, &params[..])
         .map_err(DeleteError::Client)
         .and_then(|result| {
-            serde_json::from_str::<DeleteResponse>(&result).map_err(DeleteError::MalformedResponse)
+            serde_json::from_str::<DeleteResponse>(&result)
+                .map_err(|e| DeleteError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -87,7 +88,7 @@ pub enum DeleteError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -139,7 +140,7 @@ DeleteError::InvalidPostType => "invalid_post_type: The method was called via a 
 DeleteError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 DeleteError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 DeleteError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        DeleteError::MalformedResponse(ref e) => e.description(),
+                        DeleteError::MalformedResponse(_, ref e) => e.description(),
                         DeleteError::Unknown(ref s) => s,
                         DeleteError::Client(ref inner) => inner.description()
                     }
@@ -147,7 +148,7 @@ DeleteError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            DeleteError::MalformedResponse(ref e) => Some(e),
+            DeleteError::MalformedResponse(_, ref e) => Some(e),
             DeleteError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -180,7 +181,8 @@ where
         .send(&url, &params[..])
         .map_err(InfoError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InfoResponse>(&result).map_err(InfoError::MalformedResponse)
+            serde_json::from_str::<InfoResponse>(&result)
+                .map_err(|e| InfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -243,7 +245,7 @@ pub enum InfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -293,7 +295,7 @@ InfoError::InvalidPostType => "invalid_post_type: The method was called via a PO
 InfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InfoError::MalformedResponse(ref e) => e.description(),
+                        InfoError::MalformedResponse(_, ref e) => e.description(),
                         InfoError::Unknown(ref s) => s,
                         InfoError::Client(ref inner) => inner.description()
                     }
@@ -301,7 +303,7 @@ InfoError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InfoError::MalformedResponse(ref e) => Some(e),
+            InfoError::MalformedResponse(_, ref e) => Some(e),
             InfoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -340,7 +342,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -424,7 +427,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -476,7 +479,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -484,7 +487,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -511,7 +514,7 @@ where
         .map_err(RevokePublicURLError::Client)
         .and_then(|result| {
             serde_json::from_str::<RevokePublicURLResponse>(&result)
-                .map_err(RevokePublicURLError::MalformedResponse)
+                .map_err(|e| RevokePublicURLError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -572,7 +575,7 @@ pub enum RevokePublicURLError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -624,7 +627,7 @@ RevokePublicURLError::InvalidPostType => "invalid_post_type: The method was call
 RevokePublicURLError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RevokePublicURLError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RevokePublicURLError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RevokePublicURLError::MalformedResponse(ref e) => e.description(),
+                        RevokePublicURLError::MalformedResponse(_, ref e) => e.description(),
                         RevokePublicURLError::Unknown(ref s) => s,
                         RevokePublicURLError::Client(ref inner) => inner.description()
                     }
@@ -632,7 +635,7 @@ RevokePublicURLError::RequestTimeout => "request_timeout: The method was called 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RevokePublicURLError::MalformedResponse(ref e) => Some(e),
+            RevokePublicURLError::MalformedResponse(_, ref e) => Some(e),
             RevokePublicURLError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -659,7 +662,7 @@ where
         .map_err(SharedPublicURLError::Client)
         .and_then(|result| {
             serde_json::from_str::<SharedPublicURLResponse>(&result)
-                .map_err(SharedPublicURLError::MalformedResponse)
+                .map_err(|e| SharedPublicURLError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -722,7 +725,7 @@ pub enum SharedPublicURLError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -776,7 +779,7 @@ SharedPublicURLError::InvalidPostType => "invalid_post_type: The method was call
 SharedPublicURLError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SharedPublicURLError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SharedPublicURLError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SharedPublicURLError::MalformedResponse(ref e) => e.description(),
+                        SharedPublicURLError::MalformedResponse(_, ref e) => e.description(),
                         SharedPublicURLError::Unknown(ref s) => s,
                         SharedPublicURLError::Client(ref inner) => inner.description()
                     }
@@ -784,7 +787,7 @@ SharedPublicURLError::RequestTimeout => "request_timeout: The method was called 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SharedPublicURLError::MalformedResponse(ref e) => Some(e),
+            SharedPublicURLError::MalformedResponse(_, ref e) => Some(e),
             SharedPublicURLError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/files_comments.rs
+++ b/src/mods/files_comments.rs
@@ -32,7 +32,8 @@ where
         .send(&url, &params[..])
         .map_err(AddError::Client)
         .and_then(|result| {
-            serde_json::from_str::<AddResponse>(&result).map_err(AddError::MalformedResponse)
+            serde_json::from_str::<AddResponse>(&result)
+                .map_err(|e| AddError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -93,7 +94,7 @@ pub enum AddError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -145,7 +146,7 @@ AddError::InvalidPostType => "invalid_post_type: The method was called via a POS
 AddError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 AddError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 AddError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        AddError::MalformedResponse(ref e) => e.description(),
+                        AddError::MalformedResponse(_, ref e) => e.description(),
                         AddError::Unknown(ref s) => s,
                         AddError::Client(ref inner) => inner.description()
                     }
@@ -153,7 +154,7 @@ AddError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            AddError::MalformedResponse(ref e) => Some(e),
+            AddError::MalformedResponse(_, ref e) => Some(e),
             AddError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -183,7 +184,8 @@ where
         .send(&url, &params[..])
         .map_err(DeleteError::Client)
         .and_then(|result| {
-            serde_json::from_str::<DeleteResponse>(&result).map_err(DeleteError::MalformedResponse)
+            serde_json::from_str::<DeleteResponse>(&result)
+                .map_err(|e| DeleteError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -243,7 +245,7 @@ pub enum DeleteError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -295,7 +297,7 @@ DeleteError::InvalidPostType => "invalid_post_type: The method was called via a 
 DeleteError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 DeleteError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 DeleteError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        DeleteError::MalformedResponse(ref e) => e.description(),
+                        DeleteError::MalformedResponse(_, ref e) => e.description(),
                         DeleteError::Unknown(ref s) => s,
                         DeleteError::Client(ref inner) => inner.description()
                     }
@@ -303,7 +305,7 @@ DeleteError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            DeleteError::MalformedResponse(ref e) => Some(e),
+            DeleteError::MalformedResponse(_, ref e) => Some(e),
             DeleteError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -334,7 +336,8 @@ where
         .send(&url, &params[..])
         .map_err(EditError::Client)
         .and_then(|result| {
-            serde_json::from_str::<EditResponse>(&result).map_err(EditError::MalformedResponse)
+            serde_json::from_str::<EditResponse>(&result)
+                .map_err(|e| EditError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -401,7 +404,7 @@ pub enum EditError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -457,7 +460,7 @@ EditError::InvalidPostType => "invalid_post_type: The method was called via a PO
 EditError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 EditError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 EditError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        EditError::MalformedResponse(ref e) => e.description(),
+                        EditError::MalformedResponse(_, ref e) => e.description(),
                         EditError::Unknown(ref s) => s,
                         EditError::Client(ref inner) => inner.description()
                     }
@@ -465,7 +468,7 @@ EditError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            EditError::MalformedResponse(ref e) => Some(e),
+            EditError::MalformedResponse(_, ref e) => Some(e),
             EditError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/groups.rs
+++ b/src/mods/groups.rs
@@ -650,12 +650,14 @@ pub fn history<R>(
 where
     R: SlackWebRequestSender,
 {
+    let latest = request.latest.as_ref().map(|t| t.to_param_value());
+    let oldest = request.oldest.as_ref().map(|t| t.to_param_value());
     let count = request.count.map(|count| count.to_string());
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        request.latest.map(|latest| ("latest", latest)),
-        request.oldest.map(|oldest| ("oldest", oldest)),
+        latest.as_ref().map(|latest| ("latest", &latest[..])),
+        oldest.as_ref().map(|oldest| ("oldest", &oldest[..])),
         request
             .inclusive
             .map(|inclusive| ("inclusive", if inclusive { "1" } else { "0" })),
@@ -681,9 +683,9 @@ pub struct HistoryRequest<'a> {
     /// Private channel to fetch history for.
     pub channel: &'a str,
     /// End of time range of messages to include in results.
-    pub latest: Option<&'a str>,
+    pub latest: Option<crate::Timestamp>,
     /// Start of time range of messages to include in results.
-    pub oldest: Option<&'a str>,
+    pub oldest: Option<crate::Timestamp>,
     /// Include messages with latest or oldest timestamp in results.
     pub inclusive: Option<bool>,
     /// Number of messages to return, between 1 and 1000.
@@ -1581,10 +1583,11 @@ pub fn mark<R>(
 where
     R: SlackWebRequestSender,
 {
+    let ts = request.ts.to_param_value();
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        Some(("ts", request.ts)),
+        Some(("ts", &ts[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("groups.mark");
@@ -1602,7 +1605,7 @@ pub struct MarkRequest<'a> {
     /// Private channel to set reading cursor in.
     pub channel: &'a str,
     /// Timestamp of the most recently seen message.
-    pub ts: &'a str,
+    pub ts: crate::Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -2051,10 +2054,11 @@ pub fn replies<R>(
 where
     R: SlackWebRequestSender,
 {
+    let thread_ts = request.thread_ts.to_param_value();
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        Some(("thread_ts", request.thread_ts)),
+        Some(("thread_ts", &thread_ts[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("groups.replies");
@@ -2073,7 +2077,7 @@ pub struct RepliesRequest<'a> {
     /// Private channel to fetch thread from
     pub channel: &'a str,
     /// Unique identifier of a thread's parent message
-    pub thread_ts: &'a str,
+    pub thread_ts: crate::Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/mods/groups.rs
+++ b/src/mods/groups.rs
@@ -30,7 +30,7 @@ where
         .map_err(ArchiveError::Client)
         .and_then(|result| {
             serde_json::from_str::<ArchiveResponse>(&result)
-                .map_err(ArchiveError::MalformedResponse)
+                .map_err(|e| ArchiveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -94,7 +94,7 @@ pub enum ArchiveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -152,7 +152,7 @@ ArchiveError::InvalidPostType => "invalid_post_type: The method was called via a
 ArchiveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ArchiveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ArchiveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ArchiveError::MalformedResponse(ref e) => e.description(),
+                        ArchiveError::MalformedResponse(_, ref e) => e.description(),
                         ArchiveError::Unknown(ref s) => s,
                         ArchiveError::Client(ref inner) => inner.description()
                     }
@@ -160,7 +160,7 @@ ArchiveError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ArchiveError::MalformedResponse(ref e) => Some(e),
+            ArchiveError::MalformedResponse(_, ref e) => Some(e),
             ArchiveError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -186,7 +186,8 @@ where
         .send(&url, &params[..])
         .map_err(CloseError::Client)
         .and_then(|result| {
-            serde_json::from_str::<CloseResponse>(&result).map_err(CloseError::MalformedResponse)
+            serde_json::from_str::<CloseResponse>(&result)
+                .map_err(|e| CloseError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -240,7 +241,7 @@ pub enum CloseError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -288,7 +289,7 @@ CloseError::InvalidPostType => "invalid_post_type: The method was called via a P
 CloseError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 CloseError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 CloseError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        CloseError::MalformedResponse(ref e) => e.description(),
+                        CloseError::MalformedResponse(_, ref e) => e.description(),
                         CloseError::Unknown(ref s) => s,
                         CloseError::Client(ref inner) => inner.description()
                     }
@@ -296,7 +297,7 @@ CloseError::RequestTimeout => "request_timeout: The method was called via a POST
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            CloseError::MalformedResponse(ref e) => Some(e),
+            CloseError::MalformedResponse(_, ref e) => Some(e),
             CloseError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -328,7 +329,8 @@ where
         .send(&url, &params[..])
         .map_err(CreateError::Client)
         .and_then(|result| {
-            serde_json::from_str::<CreateResponse>(&result).map_err(CreateError::MalformedResponse)
+            serde_json::from_str::<CreateResponse>(&result)
+                .map_err(|e| CreateError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -403,7 +405,7 @@ pub enum CreateError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -469,7 +471,7 @@ CreateError::InvalidPostType => "invalid_post_type: The method was called via a 
 CreateError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 CreateError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 CreateError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        CreateError::MalformedResponse(ref e) => e.description(),
+                        CreateError::MalformedResponse(_, ref e) => e.description(),
                         CreateError::Unknown(ref s) => s,
                         CreateError::Client(ref inner) => inner.description()
                     }
@@ -477,7 +479,7 @@ CreateError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            CreateError::MalformedResponse(ref e) => Some(e),
+            CreateError::MalformedResponse(_, ref e) => Some(e),
             CreateError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -504,7 +506,7 @@ where
         .map_err(CreateChildError::Client)
         .and_then(|result| {
             serde_json::from_str::<CreateChildResponse>(&result)
-                .map_err(CreateChildError::MalformedResponse)
+                .map_err(|e| CreateChildError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -567,7 +569,7 @@ pub enum CreateChildError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -623,7 +625,7 @@ CreateChildError::InvalidPostType => "invalid_post_type: The method was called v
 CreateChildError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 CreateChildError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 CreateChildError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        CreateChildError::MalformedResponse(ref e) => e.description(),
+                        CreateChildError::MalformedResponse(_, ref e) => e.description(),
                         CreateChildError::Unknown(ref s) => s,
                         CreateChildError::Client(ref inner) => inner.description()
                     }
@@ -631,7 +633,7 @@ CreateChildError::RequestTimeout => "request_timeout: The method was called via 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            CreateChildError::MalformedResponse(ref e) => Some(e),
+            CreateChildError::MalformedResponse(_, ref e) => Some(e),
             CreateChildError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -673,7 +675,7 @@ where
         .map_err(HistoryError::Client)
         .and_then(|result| {
             serde_json::from_str::<HistoryResponse>(&result)
-                .map_err(HistoryError::MalformedResponse)
+                .map_err(|e| HistoryError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -744,7 +746,7 @@ pub enum HistoryError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -796,7 +798,7 @@ HistoryError::InvalidPostType => "invalid_post_type: The method was called via a
 HistoryError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 HistoryError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 HistoryError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        HistoryError::MalformedResponse(ref e) => e.description(),
+                        HistoryError::MalformedResponse(_, ref e) => e.description(),
                         HistoryError::Unknown(ref s) => s,
                         HistoryError::Client(ref inner) => inner.description()
                     }
@@ -804,7 +806,7 @@ HistoryError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            HistoryError::MalformedResponse(ref e) => Some(e),
+            HistoryError::MalformedResponse(_, ref e) => Some(e),
             HistoryError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -830,7 +832,8 @@ where
         .send(&url, &params[..])
         .map_err(InfoError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InfoResponse>(&result).map_err(InfoError::MalformedResponse)
+            serde_json::from_str::<InfoResponse>(&result)
+                .map_err(|e| InfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -885,7 +888,7 @@ pub enum InfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -933,7 +936,7 @@ InfoError::InvalidPostType => "invalid_post_type: The method was called via a PO
 InfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InfoError::MalformedResponse(ref e) => e.description(),
+                        InfoError::MalformedResponse(_, ref e) => e.description(),
                         InfoError::Unknown(ref s) => s,
                         InfoError::Client(ref inner) => inner.description()
                     }
@@ -941,7 +944,7 @@ InfoError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InfoError::MalformedResponse(ref e) => Some(e),
+            InfoError::MalformedResponse(_, ref e) => Some(e),
             InfoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -971,7 +974,8 @@ where
         .send(&url, &params[..])
         .map_err(InviteError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InviteResponse>(&result).map_err(InviteError::MalformedResponse)
+            serde_json::from_str::<InviteResponse>(&result)
+                .map_err(|e| InviteError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1042,7 +1046,7 @@ pub enum InviteError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1104,7 +1108,7 @@ InviteError::InvalidPostType => "invalid_post_type: The method was called via a 
 InviteError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InviteError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InviteError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InviteError::MalformedResponse(ref e) => e.description(),
+                        InviteError::MalformedResponse(_, ref e) => e.description(),
                         InviteError::Unknown(ref s) => s,
                         InviteError::Client(ref inner) => inner.description()
                     }
@@ -1112,7 +1116,7 @@ InviteError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InviteError::MalformedResponse(ref e) => Some(e),
+            InviteError::MalformedResponse(_, ref e) => Some(e),
             InviteError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1142,7 +1146,8 @@ where
         .send(&url, &params[..])
         .map_err(KickError::Client)
         .and_then(|result| {
-            serde_json::from_str::<KickResponse>(&result).map_err(KickError::MalformedResponse)
+            serde_json::from_str::<KickResponse>(&result)
+                .map_err(|e| KickError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1210,7 +1215,7 @@ pub enum KickError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1270,7 +1275,7 @@ KickError::InvalidPostType => "invalid_post_type: The method was called via a PO
 KickError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 KickError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 KickError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        KickError::MalformedResponse(ref e) => e.description(),
+                        KickError::MalformedResponse(_, ref e) => e.description(),
                         KickError::Unknown(ref s) => s,
                         KickError::Client(ref inner) => inner.description()
                     }
@@ -1278,7 +1283,7 @@ KickError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            KickError::MalformedResponse(ref e) => Some(e),
+            KickError::MalformedResponse(_, ref e) => Some(e),
             KickError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1304,7 +1309,8 @@ where
         .send(&url, &params[..])
         .map_err(LeaveError::Client)
         .and_then(|result| {
-            serde_json::from_str::<LeaveResponse>(&result).map_err(LeaveError::MalformedResponse)
+            serde_json::from_str::<LeaveResponse>(&result)
+                .map_err(|e| LeaveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1364,7 +1370,7 @@ pub enum LeaveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1418,7 +1424,7 @@ LeaveError::InvalidPostType => "invalid_post_type: The method was called via a P
 LeaveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 LeaveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 LeaveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        LeaveError::MalformedResponse(ref e) => e.description(),
+                        LeaveError::MalformedResponse(_, ref e) => e.description(),
                         LeaveError::Unknown(ref s) => s,
                         LeaveError::Client(ref inner) => inner.description()
                     }
@@ -1426,7 +1432,7 @@ LeaveError::RequestTimeout => "request_timeout: The method was called via a POST
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            LeaveError::MalformedResponse(ref e) => Some(e),
+            LeaveError::MalformedResponse(_, ref e) => Some(e),
             LeaveError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1457,7 +1463,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1510,7 +1517,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1556,7 +1563,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -1564,7 +1571,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1595,7 +1602,8 @@ where
         .send(&url, &params[..])
         .map_err(MarkError::Client)
         .and_then(|result| {
-            serde_json::from_str::<MarkResponse>(&result).map_err(MarkError::MalformedResponse)
+            serde_json::from_str::<MarkResponse>(&result)
+                .map_err(|e| MarkError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1653,7 +1661,7 @@ pub enum MarkError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1703,7 +1711,7 @@ MarkError::InvalidPostType => "invalid_post_type: The method was called via a PO
 MarkError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 MarkError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 MarkError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        MarkError::MalformedResponse(ref e) => e.description(),
+                        MarkError::MalformedResponse(_, ref e) => e.description(),
                         MarkError::Unknown(ref s) => s,
                         MarkError::Client(ref inner) => inner.description()
                     }
@@ -1711,7 +1719,7 @@ MarkError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            MarkError::MalformedResponse(ref e) => Some(e),
+            MarkError::MalformedResponse(_, ref e) => Some(e),
             MarkError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1737,7 +1745,8 @@ where
         .send(&url, &params[..])
         .map_err(OpenError::Client)
         .and_then(|result| {
-            serde_json::from_str::<OpenResponse>(&result).map_err(OpenError::MalformedResponse)
+            serde_json::from_str::<OpenResponse>(&result)
+                .map_err(|e| OpenError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1791,7 +1800,7 @@ pub enum OpenError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -1839,7 +1848,7 @@ OpenError::InvalidPostType => "invalid_post_type: The method was called via a PO
 OpenError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 OpenError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 OpenError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        OpenError::MalformedResponse(ref e) => e.description(),
+                        OpenError::MalformedResponse(_, ref e) => e.description(),
                         OpenError::Unknown(ref s) => s,
                         OpenError::Client(ref inner) => inner.description()
                     }
@@ -1847,7 +1856,7 @@ OpenError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            OpenError::MalformedResponse(ref e) => Some(e),
+            OpenError::MalformedResponse(_, ref e) => Some(e),
             OpenError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -1880,7 +1889,8 @@ where
         .send(&url, &params[..])
         .map_err(RenameError::Client)
         .and_then(|result| {
-            serde_json::from_str::<RenameResponse>(&result).map_err(RenameError::MalformedResponse)
+            serde_json::from_str::<RenameResponse>(&result)
+                .map_err(|e| RenameError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -1963,7 +1973,7 @@ pub enum RenameError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -2027,7 +2037,7 @@ RenameError::InvalidPostType => "invalid_post_type: The method was called via a 
 RenameError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RenameError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RenameError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RenameError::MalformedResponse(ref e) => e.description(),
+                        RenameError::MalformedResponse(_, ref e) => e.description(),
                         RenameError::Unknown(ref s) => s,
                         RenameError::Client(ref inner) => inner.description()
                     }
@@ -2035,7 +2045,7 @@ RenameError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RenameError::MalformedResponse(ref e) => Some(e),
+            RenameError::MalformedResponse(_, ref e) => Some(e),
             RenameError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -2067,7 +2077,7 @@ where
         .map_err(RepliesError::Client)
         .and_then(|result| {
             serde_json::from_str::<RepliesResponse>(&result)
-                .map_err(RepliesError::MalformedResponse)
+                .map_err(|e| RepliesError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -2129,7 +2139,7 @@ pub enum RepliesError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -2181,7 +2191,7 @@ RepliesError::InvalidPostType => "invalid_post_type: The method was called via a
 RepliesError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RepliesError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RepliesError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RepliesError::MalformedResponse(ref e) => e.description(),
+                        RepliesError::MalformedResponse(_, ref e) => e.description(),
                         RepliesError::Unknown(ref s) => s,
                         RepliesError::Client(ref inner) => inner.description()
                     }
@@ -2189,7 +2199,7 @@ RepliesError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RepliesError::MalformedResponse(ref e) => Some(e),
+            RepliesError::MalformedResponse(_, ref e) => Some(e),
             RepliesError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -2220,7 +2230,7 @@ where
         .map_err(SetPurposeError::Client)
         .and_then(|result| {
             serde_json::from_str::<SetPurposeResponse>(&result)
-                .map_err(SetPurposeError::MalformedResponse)
+                .map_err(|e| SetPurposeError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -2283,7 +2293,7 @@ pub enum SetPurposeError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -2337,7 +2347,7 @@ SetPurposeError::InvalidPostType => "invalid_post_type: The method was called vi
 SetPurposeError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SetPurposeError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SetPurposeError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SetPurposeError::MalformedResponse(ref e) => e.description(),
+                        SetPurposeError::MalformedResponse(_, ref e) => e.description(),
                         SetPurposeError::Unknown(ref s) => s,
                         SetPurposeError::Client(ref inner) => inner.description()
                     }
@@ -2345,7 +2355,7 @@ SetPurposeError::RequestTimeout => "request_timeout: The method was called via a
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SetPurposeError::MalformedResponse(ref e) => Some(e),
+            SetPurposeError::MalformedResponse(_, ref e) => Some(e),
             SetPurposeError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -2376,7 +2386,7 @@ where
         .map_err(SetTopicError::Client)
         .and_then(|result| {
             serde_json::from_str::<SetTopicResponse>(&result)
-                .map_err(SetTopicError::MalformedResponse)
+                .map_err(|e| SetTopicError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -2439,7 +2449,7 @@ pub enum SetTopicError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -2493,7 +2503,7 @@ SetTopicError::InvalidPostType => "invalid_post_type: The method was called via 
 SetTopicError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SetTopicError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SetTopicError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SetTopicError::MalformedResponse(ref e) => e.description(),
+                        SetTopicError::MalformedResponse(_, ref e) => e.description(),
                         SetTopicError::Unknown(ref s) => s,
                         SetTopicError::Client(ref inner) => inner.description()
                     }
@@ -2501,7 +2511,7 @@ SetTopicError::RequestTimeout => "request_timeout: The method was called via a P
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SetTopicError::MalformedResponse(ref e) => Some(e),
+            SetTopicError::MalformedResponse(_, ref e) => Some(e),
             SetTopicError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -2528,7 +2538,7 @@ where
         .map_err(UnarchiveError::Client)
         .and_then(|result| {
             serde_json::from_str::<UnarchiveResponse>(&result)
-                .map_err(UnarchiveError::MalformedResponse)
+                .map_err(|e| UnarchiveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -2588,7 +2598,7 @@ pub enum UnarchiveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -2642,7 +2652,7 @@ UnarchiveError::InvalidPostType => "invalid_post_type: The method was called via
 UnarchiveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 UnarchiveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 UnarchiveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        UnarchiveError::MalformedResponse(ref e) => e.description(),
+                        UnarchiveError::MalformedResponse(_, ref e) => e.description(),
                         UnarchiveError::Unknown(ref s) => s,
                         UnarchiveError::Client(ref inner) => inner.description()
                     }
@@ -2650,7 +2660,7 @@ UnarchiveError::RequestTimeout => "request_timeout: The method was called via a 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            UnarchiveError::MalformedResponse(ref e) => Some(e),
+            UnarchiveError::MalformedResponse(_, ref e) => Some(e),
             UnarchiveError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/im.rs
+++ b/src/mods/im.rs
@@ -162,12 +162,14 @@ pub fn history<R>(
 where
     R: SlackWebRequestSender,
 {
+    let latest = request.latest.as_ref().map(|t| t.to_param_value());
+    let oldest = request.oldest.as_ref().map(|t| t.to_param_value());
     let count = request.count.map(|count| count.to_string());
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        request.latest.map(|latest| ("latest", latest)),
-        request.oldest.map(|oldest| ("oldest", oldest)),
+        latest.as_ref().map(|latest| ("latest", &latest[..])),
+        oldest.as_ref().map(|oldest| ("oldest", &oldest[..])),
         request
             .inclusive
             .map(|inclusive| ("inclusive", if inclusive { "1" } else { "0" })),
@@ -193,9 +195,9 @@ pub struct HistoryRequest<'a> {
     /// Direct message channel to fetch history for.
     pub channel: &'a str,
     /// End of time range of messages to include in results.
-    pub latest: Option<&'a str>,
+    pub latest: Option<crate::Timestamp>,
     /// Start of time range of messages to include in results.
-    pub oldest: Option<&'a str>,
+    pub oldest: Option<crate::Timestamp>,
     /// Include messages with latest or oldest timestamp in results.
     pub inclusive: Option<bool>,
     /// Number of messages to return, between 1 and 1000.
@@ -473,10 +475,11 @@ pub fn mark<R>(
 where
     R: SlackWebRequestSender,
 {
+    let ts = request.ts.to_param_value();
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        Some(("ts", request.ts)),
+        Some(("ts", &ts[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("im.mark");
@@ -494,7 +497,7 @@ pub struct MarkRequest<'a> {
     /// Direct message channel to set reading cursor in.
     pub channel: &'a str,
     /// Timestamp of the most recently seen message.
-    pub ts: &'a str,
+    pub ts: crate::Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -776,10 +779,11 @@ pub fn replies<R>(
 where
     R: SlackWebRequestSender,
 {
+    let thread_ts = request.thread_ts.to_param_value();
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        Some(("thread_ts", request.thread_ts)),
+        Some(("thread_ts", &thread_ts[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("im.replies");
@@ -798,7 +802,7 @@ pub struct RepliesRequest<'a> {
     /// Direct message channel to fetch thread from
     pub channel: &'a str,
     /// Unique identifier of a thread's parent message
-    pub thread_ts: &'a str,
+    pub thread_ts: crate::Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/mods/im.rs
+++ b/src/mods/im.rs
@@ -29,7 +29,8 @@ where
         .send(&url, &params[..])
         .map_err(CloseError::Client)
         .and_then(|result| {
-            serde_json::from_str::<CloseResponse>(&result).map_err(CloseError::MalformedResponse)
+            serde_json::from_str::<CloseResponse>(&result)
+                .map_err(|e| CloseError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -85,7 +86,7 @@ pub enum CloseError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -135,7 +136,7 @@ CloseError::InvalidPostType => "invalid_post_type: The method was called via a P
 CloseError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 CloseError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 CloseError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        CloseError::MalformedResponse(ref e) => e.description(),
+                        CloseError::MalformedResponse(_, ref e) => e.description(),
                         CloseError::Unknown(ref s) => s,
                         CloseError::Client(ref inner) => inner.description()
                     }
@@ -143,7 +144,7 @@ CloseError::RequestTimeout => "request_timeout: The method was called via a POST
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            CloseError::MalformedResponse(ref e) => Some(e),
+            CloseError::MalformedResponse(_, ref e) => Some(e),
             CloseError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -185,7 +186,7 @@ where
         .map_err(HistoryError::Client)
         .and_then(|result| {
             serde_json::from_str::<HistoryResponse>(&result)
-                .map_err(HistoryError::MalformedResponse)
+                .map_err(|e| HistoryError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -256,7 +257,7 @@ pub enum HistoryError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -308,7 +309,7 @@ HistoryError::InvalidPostType => "invalid_post_type: The method was called via a
 HistoryError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 HistoryError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 HistoryError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        HistoryError::MalformedResponse(ref e) => e.description(),
+                        HistoryError::MalformedResponse(_, ref e) => e.description(),
                         HistoryError::Unknown(ref s) => s,
                         HistoryError::Client(ref inner) => inner.description()
                     }
@@ -316,7 +317,7 @@ HistoryError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            HistoryError::MalformedResponse(ref e) => Some(e),
+            HistoryError::MalformedResponse(_, ref e) => Some(e),
             HistoryError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -347,7 +348,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -402,7 +404,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -448,7 +450,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -456,7 +458,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -487,7 +489,8 @@ where
         .send(&url, &params[..])
         .map_err(MarkError::Client)
         .and_then(|result| {
-            serde_json::from_str::<MarkResponse>(&result).map_err(MarkError::MalformedResponse)
+            serde_json::from_str::<MarkResponse>(&result)
+                .map_err(|e| MarkError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -547,7 +550,7 @@ pub enum MarkError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -599,7 +602,7 @@ MarkError::InvalidPostType => "invalid_post_type: The method was called via a PO
 MarkError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 MarkError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 MarkError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        MarkError::MalformedResponse(ref e) => e.description(),
+                        MarkError::MalformedResponse(_, ref e) => e.description(),
                         MarkError::Unknown(ref s) => s,
                         MarkError::Client(ref inner) => inner.description()
                     }
@@ -607,7 +610,7 @@ MarkError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            MarkError::MalformedResponse(ref e) => Some(e),
+            MarkError::MalformedResponse(_, ref e) => Some(e),
             MarkError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -639,7 +642,8 @@ where
         .send(&url, &params[..])
         .map_err(OpenError::Client)
         .and_then(|result| {
-            serde_json::from_str::<OpenResponse>(&result).map_err(OpenError::MalformedResponse)
+            serde_json::from_str::<OpenResponse>(&result)
+                .map_err(|e| OpenError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -700,7 +704,7 @@ pub enum OpenError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -752,7 +756,7 @@ OpenError::InvalidPostType => "invalid_post_type: The method was called via a PO
 OpenError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 OpenError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 OpenError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        OpenError::MalformedResponse(ref e) => e.description(),
+                        OpenError::MalformedResponse(_, ref e) => e.description(),
                         OpenError::Unknown(ref s) => s,
                         OpenError::Client(ref inner) => inner.description()
                     }
@@ -760,7 +764,7 @@ OpenError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            OpenError::MalformedResponse(ref e) => Some(e),
+            OpenError::MalformedResponse(_, ref e) => Some(e),
             OpenError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -792,7 +796,7 @@ where
         .map_err(RepliesError::Client)
         .and_then(|result| {
             serde_json::from_str::<RepliesResponse>(&result)
-                .map_err(RepliesError::MalformedResponse)
+                .map_err(|e| RepliesError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -854,7 +858,7 @@ pub enum RepliesError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -906,7 +910,7 @@ RepliesError::InvalidPostType => "invalid_post_type: The method was called via a
 RepliesError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RepliesError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RepliesError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RepliesError::MalformedResponse(ref e) => e.description(),
+                        RepliesError::MalformedResponse(_, ref e) => e.description(),
                         RepliesError::Unknown(ref s) => s,
                         RepliesError::Client(ref inner) => inner.description()
                     }
@@ -914,7 +918,7 @@ RepliesError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RepliesError::MalformedResponse(ref e) => Some(e),
+            RepliesError::MalformedResponse(_, ref e) => Some(e),
             RepliesError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/mpim.rs
+++ b/src/mods/mpim.rs
@@ -29,7 +29,8 @@ where
         .send(&url, &params[..])
         .map_err(CloseError::Client)
         .and_then(|result| {
-            serde_json::from_str::<CloseResponse>(&result).map_err(CloseError::MalformedResponse)
+            serde_json::from_str::<CloseResponse>(&result)
+                .map_err(|e| CloseError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -83,7 +84,7 @@ pub enum CloseError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -131,7 +132,7 @@ CloseError::InvalidPostType => "invalid_post_type: The method was called via a P
 CloseError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 CloseError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 CloseError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        CloseError::MalformedResponse(ref e) => e.description(),
+                        CloseError::MalformedResponse(_, ref e) => e.description(),
                         CloseError::Unknown(ref s) => s,
                         CloseError::Client(ref inner) => inner.description()
                     }
@@ -139,7 +140,7 @@ CloseError::RequestTimeout => "request_timeout: The method was called via a POST
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            CloseError::MalformedResponse(ref e) => Some(e),
+            CloseError::MalformedResponse(_, ref e) => Some(e),
             CloseError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -181,7 +182,7 @@ where
         .map_err(HistoryError::Client)
         .and_then(|result| {
             serde_json::from_str::<HistoryResponse>(&result)
-                .map_err(HistoryError::MalformedResponse)
+                .map_err(|e| HistoryError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -252,7 +253,7 @@ pub enum HistoryError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -304,7 +305,7 @@ HistoryError::InvalidPostType => "invalid_post_type: The method was called via a
 HistoryError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 HistoryError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 HistoryError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        HistoryError::MalformedResponse(ref e) => e.description(),
+                        HistoryError::MalformedResponse(_, ref e) => e.description(),
                         HistoryError::Unknown(ref s) => s,
                         HistoryError::Client(ref inner) => inner.description()
                     }
@@ -312,7 +313,7 @@ HistoryError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            HistoryError::MalformedResponse(ref e) => Some(e),
+            HistoryError::MalformedResponse(_, ref e) => Some(e),
             HistoryError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -333,7 +334,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -380,7 +382,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -426,7 +428,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -434,7 +436,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -465,7 +467,8 @@ where
         .send(&url, &params[..])
         .map_err(MarkError::Client)
         .and_then(|result| {
-            serde_json::from_str::<MarkResponse>(&result).map_err(MarkError::MalformedResponse)
+            serde_json::from_str::<MarkResponse>(&result)
+                .map_err(|e| MarkError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -523,7 +526,7 @@ pub enum MarkError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -573,7 +576,7 @@ MarkError::InvalidPostType => "invalid_post_type: The method was called via a PO
 MarkError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 MarkError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 MarkError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        MarkError::MalformedResponse(ref e) => e.description(),
+                        MarkError::MalformedResponse(_, ref e) => e.description(),
                         MarkError::Unknown(ref s) => s,
                         MarkError::Client(ref inner) => inner.description()
                     }
@@ -581,7 +584,7 @@ MarkError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            MarkError::MalformedResponse(ref e) => Some(e),
+            MarkError::MalformedResponse(_, ref e) => Some(e),
             MarkError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -607,7 +610,8 @@ where
         .send(&url, &params[..])
         .map_err(OpenError::Client)
         .and_then(|result| {
-            serde_json::from_str::<OpenResponse>(&result).map_err(OpenError::MalformedResponse)
+            serde_json::from_str::<OpenResponse>(&result)
+                .map_err(|e| OpenError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -666,7 +670,7 @@ pub enum OpenError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -718,7 +722,7 @@ OpenError::InvalidPostType => "invalid_post_type: The method was called via a PO
 OpenError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 OpenError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 OpenError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        OpenError::MalformedResponse(ref e) => e.description(),
+                        OpenError::MalformedResponse(_, ref e) => e.description(),
                         OpenError::Unknown(ref s) => s,
                         OpenError::Client(ref inner) => inner.description()
                     }
@@ -726,7 +730,7 @@ OpenError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            OpenError::MalformedResponse(ref e) => Some(e),
+            OpenError::MalformedResponse(_, ref e) => Some(e),
             OpenError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -758,7 +762,7 @@ where
         .map_err(RepliesError::Client)
         .and_then(|result| {
             serde_json::from_str::<RepliesResponse>(&result)
-                .map_err(RepliesError::MalformedResponse)
+                .map_err(|e| RepliesError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -820,7 +824,7 @@ pub enum RepliesError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -872,7 +876,7 @@ RepliesError::InvalidPostType => "invalid_post_type: The method was called via a
 RepliesError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RepliesError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RepliesError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RepliesError::MalformedResponse(ref e) => e.description(),
+                        RepliesError::MalformedResponse(_, ref e) => e.description(),
                         RepliesError::Unknown(ref s) => s,
                         RepliesError::Client(ref inner) => inner.description()
                     }
@@ -880,7 +884,7 @@ RepliesError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RepliesError::MalformedResponse(ref e) => Some(e),
+            RepliesError::MalformedResponse(_, ref e) => Some(e),
             RepliesError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/mpim.rs
+++ b/src/mods/mpim.rs
@@ -158,12 +158,14 @@ pub fn history<R>(
 where
     R: SlackWebRequestSender,
 {
+    let latest = request.latest.as_ref().map(|t| t.to_param_value());
+    let oldest = request.oldest.as_ref().map(|t| t.to_param_value());
     let count = request.count.map(|count| count.to_string());
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        request.latest.map(|latest| ("latest", latest)),
-        request.oldest.map(|oldest| ("oldest", oldest)),
+        latest.as_ref().map(|latest| ("latest", &latest[..])),
+        oldest.as_ref().map(|oldest| ("oldest", &oldest[..])),
         request
             .inclusive
             .map(|inclusive| ("inclusive", if inclusive { "1" } else { "0" })),
@@ -189,9 +191,9 @@ pub struct HistoryRequest<'a> {
     /// Multiparty direct message to fetch history for.
     pub channel: &'a str,
     /// End of time range of messages to include in results.
-    pub latest: Option<&'a str>,
+    pub latest: Option<crate::Timestamp>,
     /// Start of time range of messages to include in results.
-    pub oldest: Option<&'a str>,
+    pub oldest: Option<crate::Timestamp>,
     /// Include messages with latest or oldest timestamp in results.
     pub inclusive: Option<bool>,
     /// Number of messages to return, between 1 and 1000.
@@ -451,10 +453,11 @@ pub fn mark<R>(
 where
     R: SlackWebRequestSender,
 {
+    let ts = request.ts.to_param_value();
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        Some(("ts", request.ts)),
+        Some(("ts", &ts[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("mpim.mark");
@@ -472,7 +475,7 @@ pub struct MarkRequest<'a> {
     /// multiparty direct message channel to set reading cursor in.
     pub channel: &'a str,
     /// Timestamp of the most recently seen message.
-    pub ts: &'a str,
+    pub ts: crate::Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -742,10 +745,11 @@ pub fn replies<R>(
 where
     R: SlackWebRequestSender,
 {
+    let thread_ts = request.thread_ts.to_param_value();
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
-        Some(("thread_ts", request.thread_ts)),
+        Some(("thread_ts", &thread_ts[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("mpim.replies");
@@ -764,7 +768,7 @@ pub struct RepliesRequest<'a> {
     /// Multiparty direct message channel to fetch thread from.
     pub channel: &'a str,
     /// Unique identifier of a thread's parent message.
-    pub thread_ts: &'a str,
+    pub thread_ts: crate::Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/mods/pins.rs
+++ b/src/mods/pins.rs
@@ -21,6 +21,7 @@ pub fn add<R>(
 where
     R: SlackWebRequestSender,
 {
+    let timestamp = request.timestamp.as_ref().map(|t| t.to_param_value());
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
@@ -28,7 +29,9 @@ where
         request
             .file_comment
             .map(|file_comment| ("file_comment", file_comment)),
-        request.timestamp.map(|timestamp| ("timestamp", timestamp)),
+        timestamp
+            .as_ref()
+            .map(|timestamp| ("timestamp", &timestamp[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("pins.add");
@@ -50,7 +53,7 @@ pub struct AddRequest<'a> {
     /// File comment to pin.
     pub file_comment: Option<&'a str>,
     /// Timestamp of the message to pin.
-    pub timestamp: Option<&'a str>,
+    pub timestamp: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -414,6 +417,7 @@ pub fn remove<R>(
 where
     R: SlackWebRequestSender,
 {
+    let timestamp = request.timestamp.as_ref().map(|t| t.to_param_value());
     let params = vec![
         Some(("token", token)),
         Some(("channel", request.channel)),
@@ -421,7 +425,9 @@ where
         request
             .file_comment
             .map(|file_comment| ("file_comment", file_comment)),
-        request.timestamp.map(|timestamp| ("timestamp", timestamp)),
+        timestamp
+            .as_ref()
+            .map(|timestamp| ("timestamp", &timestamp[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("pins.remove");
@@ -443,7 +449,7 @@ pub struct RemoveRequest<'a> {
     /// File comment to un-pin.
     pub file_comment: Option<&'a str>,
     /// Timestamp of the message to un-pin.
-    pub timestamp: Option<&'a str>,
+    pub timestamp: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/mods/pins.rs
+++ b/src/mods/pins.rs
@@ -39,7 +39,8 @@ where
         .send(&url, &params[..])
         .map_err(AddError::Client)
         .and_then(|result| {
-            serde_json::from_str::<AddResponse>(&result).map_err(AddError::MalformedResponse)
+            serde_json::from_str::<AddResponse>(&result)
+                .map_err(|e| AddError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -115,7 +116,7 @@ pub enum AddError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -179,7 +180,7 @@ AddError::InvalidPostType => "invalid_post_type: The method was called via a POS
 AddError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 AddError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 AddError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        AddError::MalformedResponse(ref e) => e.description(),
+                        AddError::MalformedResponse(_, ref e) => e.description(),
                         AddError::Unknown(ref s) => s,
                         AddError::Client(ref inner) => inner.description()
                     }
@@ -187,7 +188,7 @@ AddError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            AddError::MalformedResponse(ref e) => Some(e),
+            AddError::MalformedResponse(_, ref e) => Some(e),
             AddError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -213,7 +214,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -342,7 +344,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -390,7 +392,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -398,7 +400,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -435,7 +437,8 @@ where
         .send(&url, &params[..])
         .map_err(RemoveError::Client)
         .and_then(|result| {
-            serde_json::from_str::<RemoveResponse>(&result).map_err(RemoveError::MalformedResponse)
+            serde_json::from_str::<RemoveResponse>(&result)
+                .map_err(|e| RemoveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -507,7 +510,7 @@ pub enum RemoveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -567,7 +570,7 @@ RemoveError::InvalidPostType => "invalid_post_type: The method was called via a 
 RemoveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RemoveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RemoveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RemoveError::MalformedResponse(ref e) => e.description(),
+                        RemoveError::MalformedResponse(_, ref e) => e.description(),
                         RemoveError::Unknown(ref s) => s,
                         RemoveError::Client(ref inner) => inner.description()
                     }
@@ -575,7 +578,7 @@ RemoveError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RemoveError::MalformedResponse(ref e) => Some(e),
+            RemoveError::MalformedResponse(_, ref e) => Some(e),
             RemoveError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/reactions.rs
+++ b/src/mods/reactions.rs
@@ -21,6 +21,7 @@ pub fn add<R>(
 where
     R: SlackWebRequestSender,
 {
+    let timestamp = request.timestamp.as_ref().map(|t| t.to_param_value());
     let params = vec![
         Some(("token", token)),
         Some(("name", request.name)),
@@ -29,7 +30,9 @@ where
             .file_comment
             .map(|file_comment| ("file_comment", file_comment)),
         request.channel.map(|channel| ("channel", channel)),
-        request.timestamp.map(|timestamp| ("timestamp", timestamp)),
+        timestamp
+            .as_ref()
+            .map(|timestamp| ("timestamp", &timestamp[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("reactions.add");
@@ -53,7 +56,7 @@ pub struct AddRequest<'a> {
     /// Channel where the message to add reaction to was posted.
     pub channel: Option<&'a str>,
     /// Timestamp of the message to add reaction to.
-    pub timestamp: Option<&'a str>,
+    pub timestamp: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -206,6 +209,7 @@ pub fn get<R>(
 where
     R: SlackWebRequestSender,
 {
+    let timestamp = request.timestamp.as_ref().map(|t| t.to_param_value());
     let params = vec![
         Some(("token", token)),
         request.file.map(|file| ("file", file)),
@@ -213,7 +217,9 @@ where
             .file_comment
             .map(|file_comment| ("file_comment", file_comment)),
         request.channel.map(|channel| ("channel", channel)),
-        request.timestamp.map(|timestamp| ("timestamp", timestamp)),
+        timestamp
+            .as_ref()
+            .map(|timestamp| ("timestamp", &timestamp[..])),
         request
             .full
             .map(|full| ("full", if full { "1" } else { "0" })),
@@ -238,7 +244,7 @@ pub struct GetRequest<'a> {
     /// Channel where the message to get reactions for was posted.
     pub channel: Option<&'a str>,
     /// Timestamp of the message to get reactions for.
-    pub timestamp: Option<&'a str>,
+    pub timestamp: Option<crate::Timestamp>,
     /// If true always return the complete reaction list.
     pub full: Option<bool>,
 }
@@ -706,6 +712,7 @@ pub fn remove<R>(
 where
     R: SlackWebRequestSender,
 {
+    let timestamp = request.timestamp.as_ref().map(|t| t.to_param_value());
     let params = vec![
         Some(("token", token)),
         Some(("name", request.name)),
@@ -714,7 +721,9 @@ where
             .file_comment
             .map(|file_comment| ("file_comment", file_comment)),
         request.channel.map(|channel| ("channel", channel)),
-        request.timestamp.map(|timestamp| ("timestamp", timestamp)),
+        timestamp
+            .as_ref()
+            .map(|timestamp| ("timestamp", &timestamp[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("reactions.remove");
@@ -738,7 +747,7 @@ pub struct RemoveRequest<'a> {
     /// Channel where the message to remove reaction from was posted.
     pub channel: Option<&'a str>,
     /// Timestamp of the message to remove reaction from.
-    pub timestamp: Option<&'a str>,
+    pub timestamp: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/mods/reactions.rs
+++ b/src/mods/reactions.rs
@@ -40,7 +40,8 @@ where
         .send(&url, &params[..])
         .map_err(AddError::Client)
         .and_then(|result| {
-            serde_json::from_str::<AddResponse>(&result).map_err(AddError::MalformedResponse)
+            serde_json::from_str::<AddResponse>(&result)
+                .map_err(|e| AddError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -118,7 +119,7 @@ pub enum AddError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -182,7 +183,7 @@ AddError::InvalidPostType => "invalid_post_type: The method was called via a POS
 AddError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 AddError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 AddError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        AddError::MalformedResponse(ref e) => e.description(),
+                        AddError::MalformedResponse(_, ref e) => e.description(),
                         AddError::Unknown(ref s) => s,
                         AddError::Client(ref inner) => inner.description()
                     }
@@ -190,7 +191,7 @@ AddError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            AddError::MalformedResponse(ref e) => Some(e),
+            AddError::MalformedResponse(_, ref e) => Some(e),
             AddError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -230,7 +231,8 @@ where
         .send(&url, &params[..])
         .map_err(GetError::Client)
         .and_then(|result| {
-            serde_json::from_str::<GetResponse>(&result).map_err(GetError::MalformedResponse)
+            serde_json::from_str::<GetResponse>(&result)
+                .map_err(|e| GetError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -407,7 +409,7 @@ pub enum GetError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -463,7 +465,7 @@ GetError::InvalidPostType => "invalid_post_type: The method was called via a POS
 GetError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 GetError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 GetError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        GetError::MalformedResponse(ref e) => e.description(),
+                        GetError::MalformedResponse(_, ref e) => e.description(),
                         GetError::Unknown(ref s) => s,
                         GetError::Client(ref inner) => inner.description()
                     }
@@ -471,7 +473,7 @@ GetError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            GetError::MalformedResponse(ref e) => Some(e),
+            GetError::MalformedResponse(_, ref e) => Some(e),
             GetError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -507,7 +509,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -637,7 +640,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -685,7 +688,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -693,7 +696,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -731,7 +734,8 @@ where
         .send(&url, &params[..])
         .map_err(RemoveError::Client)
         .and_then(|result| {
-            serde_json::from_str::<RemoveResponse>(&result).map_err(RemoveError::MalformedResponse)
+            serde_json::from_str::<RemoveResponse>(&result)
+                .map_err(|e| RemoveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -805,7 +809,7 @@ pub enum RemoveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -865,7 +869,7 @@ RemoveError::InvalidPostType => "invalid_post_type: The method was called via a 
 RemoveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RemoveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RemoveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RemoveError::MalformedResponse(ref e) => e.description(),
+                        RemoveError::MalformedResponse(_, ref e) => e.description(),
                         RemoveError::Unknown(ref s) => s,
                         RemoveError::Client(ref inner) => inner.description()
                     }
@@ -873,7 +877,7 @@ RemoveError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RemoveError::MalformedResponse(ref e) => Some(e),
+            RemoveError::MalformedResponse(_, ref e) => Some(e),
             RemoveError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/reminders.rs
+++ b/src/mods/reminders.rs
@@ -34,7 +34,8 @@ where
         .send(&url, &params[..])
         .map_err(AddError::Client)
         .and_then(|result| {
-            serde_json::from_str::<AddResponse>(&result).map_err(AddError::MalformedResponse)
+            serde_json::from_str::<AddResponse>(&result)
+                .map_err(|e| AddError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -105,7 +106,7 @@ pub enum AddError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -165,7 +166,7 @@ AddError::InvalidPostType => "invalid_post_type: The method was called via a POS
 AddError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 AddError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 AddError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        AddError::MalformedResponse(ref e) => e.description(),
+                        AddError::MalformedResponse(_, ref e) => e.description(),
                         AddError::Unknown(ref s) => s,
                         AddError::Client(ref inner) => inner.description()
                     }
@@ -173,7 +174,7 @@ AddError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            AddError::MalformedResponse(ref e) => Some(e),
+            AddError::MalformedResponse(_, ref e) => Some(e),
             AddError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -200,7 +201,7 @@ where
         .map_err(CompleteError::Client)
         .and_then(|result| {
             serde_json::from_str::<CompleteResponse>(&result)
-                .map_err(CompleteError::MalformedResponse)
+                .map_err(|e| CompleteError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -260,7 +261,7 @@ pub enum CompleteError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -314,7 +315,7 @@ CompleteError::InvalidPostType => "invalid_post_type: The method was called via 
 CompleteError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 CompleteError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 CompleteError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        CompleteError::MalformedResponse(ref e) => e.description(),
+                        CompleteError::MalformedResponse(_, ref e) => e.description(),
                         CompleteError::Unknown(ref s) => s,
                         CompleteError::Client(ref inner) => inner.description()
                     }
@@ -322,7 +323,7 @@ CompleteError::RequestTimeout => "request_timeout: The method was called via a P
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            CompleteError::MalformedResponse(ref e) => Some(e),
+            CompleteError::MalformedResponse(_, ref e) => Some(e),
             CompleteError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -348,7 +349,8 @@ where
         .send(&url, &params[..])
         .map_err(DeleteError::Client)
         .and_then(|result| {
-            serde_json::from_str::<DeleteResponse>(&result).map_err(DeleteError::MalformedResponse)
+            serde_json::from_str::<DeleteResponse>(&result)
+                .map_err(|e| DeleteError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -404,7 +406,7 @@ pub enum DeleteError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -454,7 +456,7 @@ DeleteError::InvalidPostType => "invalid_post_type: The method was called via a 
 DeleteError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 DeleteError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 DeleteError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        DeleteError::MalformedResponse(ref e) => e.description(),
+                        DeleteError::MalformedResponse(_, ref e) => e.description(),
                         DeleteError::Unknown(ref s) => s,
                         DeleteError::Client(ref inner) => inner.description()
                     }
@@ -462,7 +464,7 @@ DeleteError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            DeleteError::MalformedResponse(ref e) => Some(e),
+            DeleteError::MalformedResponse(_, ref e) => Some(e),
             DeleteError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -488,7 +490,8 @@ where
         .send(&url, &params[..])
         .map_err(InfoError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InfoResponse>(&result).map_err(InfoError::MalformedResponse)
+            serde_json::from_str::<InfoResponse>(&result)
+                .map_err(|e| InfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -545,7 +548,7 @@ pub enum InfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -595,7 +598,7 @@ InfoError::InvalidPostType => "invalid_post_type: The method was called via a PO
 InfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InfoError::MalformedResponse(ref e) => e.description(),
+                        InfoError::MalformedResponse(_, ref e) => e.description(),
                         InfoError::Unknown(ref s) => s,
                         InfoError::Client(ref inner) => inner.description()
                     }
@@ -603,7 +606,7 @@ InfoError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InfoError::MalformedResponse(ref e) => Some(e),
+            InfoError::MalformedResponse(_, ref e) => Some(e),
             InfoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -624,7 +627,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -673,7 +677,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -721,7 +725,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -729,7 +733,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/rtm.rs
+++ b/src/mods/rtm.rs
@@ -24,7 +24,7 @@ where
         .map_err(ConnectError::Client)
         .and_then(|result| {
             serde_json::from_str::<ConnectResponse>(&result)
-                .map_err(ConnectError::MalformedResponse)
+                .map_err(|e| ConnectError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -89,7 +89,7 @@ pub enum ConnectError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -135,7 +135,7 @@ ConnectError::InvalidPostType => "invalid_post_type: The method was called via a
 ConnectError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ConnectError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ConnectError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ConnectError::MalformedResponse(ref e) => e.description(),
+                        ConnectError::MalformedResponse(_, ref e) => e.description(),
                         ConnectError::Unknown(ref s) => s,
                         ConnectError::Client(ref inner) => inner.description()
                     }
@@ -143,7 +143,7 @@ ConnectError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ConnectError::MalformedResponse(ref e) => Some(e),
+            ConnectError::MalformedResponse(_, ref e) => Some(e),
             ConnectError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -189,7 +189,8 @@ where
         .send(&url, &params[..])
         .map_err(StartError::Client)
         .and_then(|result| {
-            serde_json::from_str::<StartResponse>(&result).map_err(StartError::MalformedResponse)
+            serde_json::from_str::<StartResponse>(&result)
+                .map_err(|e| StartError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -261,7 +262,7 @@ pub enum StartError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -309,7 +310,7 @@ StartError::InvalidPostType => "invalid_post_type: The method was called via a P
 StartError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 StartError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 StartError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        StartError::MalformedResponse(ref e) => e.description(),
+                        StartError::MalformedResponse(_, ref e) => e.description(),
                         StartError::Unknown(ref s) => s,
                         StartError::Client(ref inner) => inner.description()
                     }
@@ -317,7 +318,7 @@ StartError::RequestTimeout => "request_timeout: The method was called via a POST
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            StartError::MalformedResponse(ref e) => Some(e),
+            StartError::MalformedResponse(_, ref e) => Some(e),
             StartError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/search.rs
+++ b/src/mods/search.rs
@@ -41,7 +41,8 @@ where
         .send(&url, &params[..])
         .map_err(AllError::Client)
         .and_then(|result| {
-            serde_json::from_str::<AllResponse>(&result).map_err(AllError::MalformedResponse)
+            serde_json::from_str::<AllResponse>(&result)
+                .map_err(|e| AllError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -120,7 +121,7 @@ pub enum AllError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -168,7 +169,7 @@ AllError::InvalidPostType => "invalid_post_type: The method was called via a POS
 AllError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 AllError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 AllError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        AllError::MalformedResponse(ref e) => e.description(),
+                        AllError::MalformedResponse(_, ref e) => e.description(),
                         AllError::Unknown(ref s) => s,
                         AllError::Client(ref inner) => inner.description()
                     }
@@ -176,7 +177,7 @@ AllError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            AllError::MalformedResponse(ref e) => Some(e),
+            AllError::MalformedResponse(_, ref e) => Some(e),
             AllError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -214,7 +215,8 @@ where
         .send(&url, &params[..])
         .map_err(FilesError::Client)
         .and_then(|result| {
-            serde_json::from_str::<FilesResponse>(&result).map_err(FilesError::MalformedResponse)
+            serde_json::from_str::<FilesResponse>(&result)
+                .map_err(|e| FilesError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -287,7 +289,7 @@ pub enum FilesError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -335,7 +337,7 @@ FilesError::InvalidPostType => "invalid_post_type: The method was called via a P
 FilesError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 FilesError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 FilesError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        FilesError::MalformedResponse(ref e) => e.description(),
+                        FilesError::MalformedResponse(_, ref e) => e.description(),
                         FilesError::Unknown(ref s) => s,
                         FilesError::Client(ref inner) => inner.description()
                     }
@@ -343,7 +345,7 @@ FilesError::RequestTimeout => "request_timeout: The method was called via a POST
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            FilesError::MalformedResponse(ref e) => Some(e),
+            FilesError::MalformedResponse(_, ref e) => Some(e),
             FilesError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -382,7 +384,7 @@ where
         .map_err(MessagesError::Client)
         .and_then(|result| {
             serde_json::from_str::<MessagesResponse>(&result)
-                .map_err(MessagesError::MalformedResponse)
+                .map_err(|e| MessagesError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -455,7 +457,7 @@ pub enum MessagesError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -503,7 +505,7 @@ MessagesError::InvalidPostType => "invalid_post_type: The method was called via 
 MessagesError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 MessagesError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 MessagesError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        MessagesError::MalformedResponse(ref e) => e.description(),
+                        MessagesError::MalformedResponse(_, ref e) => e.description(),
                         MessagesError::Unknown(ref s) => s,
                         MessagesError::Client(ref inner) => inner.description()
                     }
@@ -511,7 +513,7 @@ MessagesError::RequestTimeout => "request_timeout: The method was called via a P
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            MessagesError::MalformedResponse(ref e) => Some(e),
+            MessagesError::MalformedResponse(_, ref e) => Some(e),
             MessagesError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/stars.rs
+++ b/src/mods/stars.rs
@@ -21,6 +21,7 @@ pub fn add<R>(
 where
     R: SlackWebRequestSender,
 {
+    let timestamp = request.timestamp.as_ref().map(|t| t.to_param_value());
     let params = vec![
         Some(("token", token)),
         request.file.map(|file| ("file", file)),
@@ -28,7 +29,9 @@ where
             .file_comment
             .map(|file_comment| ("file_comment", file_comment)),
         request.channel.map(|channel| ("channel", channel)),
-        request.timestamp.map(|timestamp| ("timestamp", timestamp)),
+        timestamp
+            .as_ref()
+            .map(|timestamp| ("timestamp", &timestamp[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("stars.add");
@@ -50,7 +53,7 @@ pub struct AddRequest<'a> {
     /// Channel to add star to, or channel where the message to add star to was posted (used with timestamp).
     pub channel: Option<&'a str>,
     /// Timestamp of the message to add star to.
-    pub timestamp: Option<&'a str>,
+    pub timestamp: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -451,6 +454,7 @@ pub fn remove<R>(
 where
     R: SlackWebRequestSender,
 {
+    let timestamp = request.timestamp.as_ref().map(|t| t.to_param_value());
     let params = vec![
         Some(("token", token)),
         request.file.map(|file| ("file", file)),
@@ -458,7 +462,9 @@ where
             .file_comment
             .map(|file_comment| ("file_comment", file_comment)),
         request.channel.map(|channel| ("channel", channel)),
-        request.timestamp.map(|timestamp| ("timestamp", timestamp)),
+        timestamp
+            .as_ref()
+            .map(|timestamp| ("timestamp", &timestamp[..])),
     ];
     let params = params.into_iter().filter_map(|x| x).collect::<Vec<_>>();
     let url = crate::get_slack_url_for_method("stars.remove");
@@ -480,7 +486,7 @@ pub struct RemoveRequest<'a> {
     /// Channel to remove star from, or channel where the message to remove star from was posted (used with timestamp).
     pub channel: Option<&'a str>,
     /// Timestamp of the message to remove star from.
-    pub timestamp: Option<&'a str>,
+    pub timestamp: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/mods/stars.rs
+++ b/src/mods/stars.rs
@@ -39,7 +39,8 @@ where
         .send(&url, &params[..])
         .map_err(AddError::Client)
         .and_then(|result| {
-            serde_json::from_str::<AddResponse>(&result).map_err(AddError::MalformedResponse)
+            serde_json::from_str::<AddResponse>(&result)
+                .map_err(|e| AddError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -111,7 +112,7 @@ pub enum AddError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -171,7 +172,7 @@ AddError::InvalidPostType => "invalid_post_type: The method was called via a POS
 AddError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 AddError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 AddError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        AddError::MalformedResponse(ref e) => e.description(),
+                        AddError::MalformedResponse(_, ref e) => e.description(),
                         AddError::Unknown(ref s) => s,
                         AddError::Client(ref inner) => inner.description()
                     }
@@ -179,7 +180,7 @@ AddError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            AddError::MalformedResponse(ref e) => Some(e),
+            AddError::MalformedResponse(_, ref e) => Some(e),
             AddError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -211,7 +212,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -375,7 +377,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -427,7 +429,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -435,7 +437,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -472,7 +474,8 @@ where
         .send(&url, &params[..])
         .map_err(RemoveError::Client)
         .and_then(|result| {
-            serde_json::from_str::<RemoveResponse>(&result).map_err(RemoveError::MalformedResponse)
+            serde_json::from_str::<RemoveResponse>(&result)
+                .map_err(|e| RemoveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -544,7 +547,7 @@ pub enum RemoveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -604,7 +607,7 @@ RemoveError::InvalidPostType => "invalid_post_type: The method was called via a 
 RemoveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 RemoveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 RemoveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        RemoveError::MalformedResponse(ref e) => e.description(),
+                        RemoveError::MalformedResponse(_, ref e) => e.description(),
                         RemoveError::Unknown(ref s) => s,
                         RemoveError::Client(ref inner) => inner.description()
                     }
@@ -612,7 +615,7 @@ RemoveError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            RemoveError::MalformedResponse(ref e) => Some(e),
+            RemoveError::MalformedResponse(_, ref e) => Some(e),
             RemoveError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/team.rs
+++ b/src/mods/team.rs
@@ -37,7 +37,7 @@ where
         .map_err(AccessLogsError::Client)
         .and_then(|result| {
             serde_json::from_str::<AccessLogsResponse>(&result)
-                .map_err(AccessLogsError::MalformedResponse)
+                .map_err(|e| AccessLogsError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -115,7 +115,7 @@ pub enum AccessLogsError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -167,7 +167,7 @@ AccessLogsError::InvalidPostType => "invalid_post_type: The method was called vi
 AccessLogsError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 AccessLogsError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 AccessLogsError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        AccessLogsError::MalformedResponse(ref e) => e.description(),
+                        AccessLogsError::MalformedResponse(_, ref e) => e.description(),
                         AccessLogsError::Unknown(ref s) => s,
                         AccessLogsError::Client(ref inner) => inner.description()
                     }
@@ -175,7 +175,7 @@ AccessLogsError::RequestTimeout => "request_timeout: The method was called via a
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            AccessLogsError::MalformedResponse(ref e) => Some(e),
+            AccessLogsError::MalformedResponse(_, ref e) => Some(e),
             AccessLogsError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -205,7 +205,7 @@ where
         .map_err(BillableInfoError::Client)
         .and_then(|result| {
             serde_json::from_str::<BillableInfoResponse>(&result)
-                .map_err(BillableInfoError::MalformedResponse)
+                .map_err(|e| BillableInfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -262,7 +262,7 @@ pub enum BillableInfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -312,7 +312,7 @@ BillableInfoError::InvalidPostType => "invalid_post_type: The method was called 
 BillableInfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 BillableInfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 BillableInfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        BillableInfoError::MalformedResponse(ref e) => e.description(),
+                        BillableInfoError::MalformedResponse(_, ref e) => e.description(),
                         BillableInfoError::Unknown(ref s) => s,
                         BillableInfoError::Client(ref inner) => inner.description()
                     }
@@ -320,7 +320,7 @@ BillableInfoError::RequestTimeout => "request_timeout: The method was called via
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            BillableInfoError::MalformedResponse(ref e) => Some(e),
+            BillableInfoError::MalformedResponse(_, ref e) => Some(e),
             BillableInfoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -341,7 +341,8 @@ where
         .send(&url, &params[..])
         .map_err(InfoError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InfoResponse>(&result).map_err(InfoError::MalformedResponse)
+            serde_json::from_str::<InfoResponse>(&result)
+                .map_err(|e| InfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -388,7 +389,7 @@ pub enum InfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -434,7 +435,7 @@ InfoError::InvalidPostType => "invalid_post_type: The method was called via a PO
 InfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InfoError::MalformedResponse(ref e) => e.description(),
+                        InfoError::MalformedResponse(_, ref e) => e.description(),
                         InfoError::Unknown(ref s) => s,
                         InfoError::Client(ref inner) => inner.description()
                     }
@@ -442,7 +443,7 @@ InfoError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InfoError::MalformedResponse(ref e) => Some(e),
+            InfoError::MalformedResponse(_, ref e) => Some(e),
             InfoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -483,7 +484,7 @@ where
         .map_err(IntegrationLogsError::Client)
         .and_then(|result| {
             serde_json::from_str::<IntegrationLogsResponse>(&result)
-                .map_err(IntegrationLogsError::MalformedResponse)
+                .map_err(|e| IntegrationLogsError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -566,7 +567,7 @@ pub enum IntegrationLogsError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -614,7 +615,7 @@ IntegrationLogsError::InvalidPostType => "invalid_post_type: The method was call
 IntegrationLogsError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 IntegrationLogsError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 IntegrationLogsError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        IntegrationLogsError::MalformedResponse(ref e) => e.description(),
+                        IntegrationLogsError::MalformedResponse(_, ref e) => e.description(),
                         IntegrationLogsError::Unknown(ref s) => s,
                         IntegrationLogsError::Client(ref inner) => inner.description()
                     }
@@ -622,7 +623,7 @@ IntegrationLogsError::RequestTimeout => "request_timeout: The method was called 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            IntegrationLogsError::MalformedResponse(ref e) => Some(e),
+            IntegrationLogsError::MalformedResponse(_, ref e) => Some(e),
             IntegrationLogsError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/usergroups.rs
+++ b/src/mods/usergroups.rs
@@ -40,7 +40,8 @@ where
         .send(&url, &params[..])
         .map_err(CreateError::Client)
         .and_then(|result| {
-            serde_json::from_str::<CreateResponse>(&result).map_err(CreateError::MalformedResponse)
+            serde_json::from_str::<CreateResponse>(&result)
+                .map_err(|e| CreateError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -105,7 +106,7 @@ pub enum CreateError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -155,7 +156,7 @@ CreateError::InvalidPostType => "invalid_post_type: The method was called via a 
 CreateError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 CreateError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 CreateError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        CreateError::MalformedResponse(ref e) => e.description(),
+                        CreateError::MalformedResponse(_, ref e) => e.description(),
                         CreateError::Unknown(ref s) => s,
                         CreateError::Client(ref inner) => inner.description()
                     }
@@ -163,7 +164,7 @@ CreateError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            CreateError::MalformedResponse(ref e) => Some(e),
+            CreateError::MalformedResponse(_, ref e) => Some(e),
             CreateError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -196,7 +197,7 @@ where
         .map_err(DisableError::Client)
         .and_then(|result| {
             serde_json::from_str::<DisableResponse>(&result)
-                .map_err(DisableError::MalformedResponse)
+                .map_err(|e| DisableError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -255,7 +256,7 @@ pub enum DisableError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -305,7 +306,7 @@ DisableError::InvalidPostType => "invalid_post_type: The method was called via a
 DisableError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 DisableError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 DisableError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        DisableError::MalformedResponse(ref e) => e.description(),
+                        DisableError::MalformedResponse(_, ref e) => e.description(),
                         DisableError::Unknown(ref s) => s,
                         DisableError::Client(ref inner) => inner.description()
                     }
@@ -313,7 +314,7 @@ DisableError::RequestTimeout => "request_timeout: The method was called via a PO
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            DisableError::MalformedResponse(ref e) => Some(e),
+            DisableError::MalformedResponse(_, ref e) => Some(e),
             DisableError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -345,7 +346,8 @@ where
         .send(&url, &params[..])
         .map_err(EnableError::Client)
         .and_then(|result| {
-            serde_json::from_str::<EnableResponse>(&result).map_err(EnableError::MalformedResponse)
+            serde_json::from_str::<EnableResponse>(&result)
+                .map_err(|e| EnableError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -404,7 +406,7 @@ pub enum EnableError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -454,7 +456,7 @@ EnableError::InvalidPostType => "invalid_post_type: The method was called via a 
 EnableError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 EnableError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 EnableError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        EnableError::MalformedResponse(ref e) => e.description(),
+                        EnableError::MalformedResponse(_, ref e) => e.description(),
                         EnableError::Unknown(ref s) => s,
                         EnableError::Client(ref inner) => inner.description()
                     }
@@ -462,7 +464,7 @@ EnableError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            EnableError::MalformedResponse(ref e) => Some(e),
+            EnableError::MalformedResponse(_, ref e) => Some(e),
             EnableError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -499,7 +501,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -560,7 +563,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -610,7 +613,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -618,7 +621,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -656,7 +659,8 @@ where
         .send(&url, &params[..])
         .map_err(UpdateError::Client)
         .and_then(|result| {
-            serde_json::from_str::<UpdateResponse>(&result).map_err(UpdateError::MalformedResponse)
+            serde_json::from_str::<UpdateResponse>(&result)
+                .map_err(|e| UpdateError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -723,7 +727,7 @@ pub enum UpdateError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -773,7 +777,7 @@ UpdateError::InvalidPostType => "invalid_post_type: The method was called via a 
 UpdateError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 UpdateError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 UpdateError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        UpdateError::MalformedResponse(ref e) => e.description(),
+                        UpdateError::MalformedResponse(_, ref e) => e.description(),
                         UpdateError::Unknown(ref s) => s,
                         UpdateError::Client(ref inner) => inner.description()
                     }
@@ -781,7 +785,7 @@ UpdateError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            UpdateError::MalformedResponse(ref e) => Some(e),
+            UpdateError::MalformedResponse(_, ref e) => Some(e),
             UpdateError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/usergroups_users.rs
+++ b/src/mods/usergroups_users.rs
@@ -34,7 +34,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -93,7 +94,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -143,7 +144,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -151,7 +152,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -184,7 +185,8 @@ where
         .send(&url, &params[..])
         .map_err(UpdateError::Client)
         .and_then(|result| {
-            serde_json::from_str::<UpdateResponse>(&result).map_err(UpdateError::MalformedResponse)
+            serde_json::from_str::<UpdateResponse>(&result)
+                .map_err(|e| UpdateError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -245,7 +247,7 @@ pub enum UpdateError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -295,7 +297,7 @@ UpdateError::InvalidPostType => "invalid_post_type: The method was called via a 
 UpdateError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 UpdateError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 UpdateError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        UpdateError::MalformedResponse(ref e) => e.description(),
+                        UpdateError::MalformedResponse(_, ref e) => e.description(),
                         UpdateError::Unknown(ref s) => s,
                         UpdateError::Client(ref inner) => inner.description()
                     }
@@ -303,7 +305,7 @@ UpdateError::RequestTimeout => "request_timeout: The method was called via a POS
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            UpdateError::MalformedResponse(ref e) => Some(e),
+            UpdateError::MalformedResponse(_, ref e) => Some(e),
             UpdateError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/users.rs
+++ b/src/mods/users.rs
@@ -28,7 +28,7 @@ where
         .map_err(DeletePhotoError::Client)
         .and_then(|result| {
             serde_json::from_str::<DeletePhotoResponse>(&result)
-                .map_err(DeletePhotoError::MalformedResponse)
+                .map_err(|e| DeletePhotoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -76,7 +76,7 @@ pub enum DeletePhotoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -124,7 +124,7 @@ DeletePhotoError::InvalidPostType => "invalid_post_type: The method was called v
 DeletePhotoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 DeletePhotoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 DeletePhotoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        DeletePhotoError::MalformedResponse(ref e) => e.description(),
+                        DeletePhotoError::MalformedResponse(_, ref e) => e.description(),
                         DeletePhotoError::Unknown(ref s) => s,
                         DeletePhotoError::Client(ref inner) => inner.description()
                     }
@@ -132,7 +132,7 @@ DeletePhotoError::RequestTimeout => "request_timeout: The method was called via 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            DeletePhotoError::MalformedResponse(ref e) => Some(e),
+            DeletePhotoError::MalformedResponse(_, ref e) => Some(e),
             DeletePhotoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -159,7 +159,7 @@ where
         .map_err(GetPresenceError::Client)
         .and_then(|result| {
             serde_json::from_str::<GetPresenceResponse>(&result)
-                .map_err(GetPresenceError::MalformedResponse)
+                .map_err(|e| GetPresenceError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -212,7 +212,7 @@ pub enum GetPresenceError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -258,7 +258,7 @@ GetPresenceError::InvalidPostType => "invalid_post_type: The method was called v
 GetPresenceError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 GetPresenceError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 GetPresenceError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        GetPresenceError::MalformedResponse(ref e) => e.description(),
+                        GetPresenceError::MalformedResponse(_, ref e) => e.description(),
                         GetPresenceError::Unknown(ref s) => s,
                         GetPresenceError::Client(ref inner) => inner.description()
                     }
@@ -266,7 +266,7 @@ GetPresenceError::RequestTimeout => "request_timeout: The method was called via 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            GetPresenceError::MalformedResponse(ref e) => Some(e),
+            GetPresenceError::MalformedResponse(_, ref e) => Some(e),
             GetPresenceError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -288,7 +288,7 @@ where
         .map_err(IdentityError::Client)
         .and_then(|result| {
             serde_json::from_str::<IdentityResponse>(&result)
-                .map_err(IdentityError::MalformedResponse)
+                .map_err(|e| IdentityError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -338,7 +338,7 @@ pub enum IdentityError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -386,7 +386,7 @@ IdentityError::InvalidPostType => "invalid_post_type: The method was called via 
 IdentityError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 IdentityError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 IdentityError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        IdentityError::MalformedResponse(ref e) => e.description(),
+                        IdentityError::MalformedResponse(_, ref e) => e.description(),
                         IdentityError::Unknown(ref s) => s,
                         IdentityError::Client(ref inner) => inner.description()
                     }
@@ -394,7 +394,7 @@ IdentityError::RequestTimeout => "request_timeout: The method was called via a P
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            IdentityError::MalformedResponse(ref e) => Some(e),
+            IdentityError::MalformedResponse(_, ref e) => Some(e),
             IdentityError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -420,7 +420,8 @@ where
         .send(&url, &params[..])
         .map_err(InfoError::Client)
         .and_then(|result| {
-            serde_json::from_str::<InfoResponse>(&result).map_err(InfoError::MalformedResponse)
+            serde_json::from_str::<InfoResponse>(&result)
+                .map_err(|e| InfoError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -477,7 +478,7 @@ pub enum InfoError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -527,7 +528,7 @@ InfoError::InvalidPostType => "invalid_post_type: The method was called via a PO
 InfoError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 InfoError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 InfoError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        InfoError::MalformedResponse(ref e) => e.description(),
+                        InfoError::MalformedResponse(_, ref e) => e.description(),
                         InfoError::Unknown(ref s) => s,
                         InfoError::Client(ref inner) => inner.description()
                     }
@@ -535,7 +536,7 @@ InfoError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            InfoError::MalformedResponse(ref e) => Some(e),
+            InfoError::MalformedResponse(_, ref e) => Some(e),
             InfoError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -566,7 +567,8 @@ where
         .send(&url, &params[..])
         .map_err(ListError::Client)
         .and_then(|result| {
-            serde_json::from_str::<ListResponse>(&result).map_err(ListError::MalformedResponse)
+            serde_json::from_str::<ListResponse>(&result)
+                .map_err(|e| ListError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -619,7 +621,7 @@ pub enum ListError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -665,7 +667,7 @@ ListError::InvalidPostType => "invalid_post_type: The method was called via a PO
 ListError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 ListError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 ListError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        ListError::MalformedResponse(ref e) => e.description(),
+                        ListError::MalformedResponse(_, ref e) => e.description(),
                         ListError::Unknown(ref s) => s,
                         ListError::Client(ref inner) => inner.description()
                     }
@@ -673,7 +675,7 @@ ListError::RequestTimeout => "request_timeout: The method was called via a POST 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            ListError::MalformedResponse(ref e) => Some(e),
+            ListError::MalformedResponse(_, ref e) => Some(e),
             ListError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -695,7 +697,7 @@ where
         .map_err(SetActiveError::Client)
         .and_then(|result| {
             serde_json::from_str::<SetActiveResponse>(&result)
-                .map_err(SetActiveError::MalformedResponse)
+                .map_err(|e| SetActiveError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -741,7 +743,7 @@ pub enum SetActiveError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -787,7 +789,7 @@ SetActiveError::InvalidPostType => "invalid_post_type: The method was called via
 SetActiveError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SetActiveError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SetActiveError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SetActiveError::MalformedResponse(ref e) => e.description(),
+                        SetActiveError::MalformedResponse(_, ref e) => e.description(),
                         SetActiveError::Unknown(ref s) => s,
                         SetActiveError::Client(ref inner) => inner.description()
                     }
@@ -795,7 +797,7 @@ SetActiveError::RequestTimeout => "request_timeout: The method was called via a 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SetActiveError::MalformedResponse(ref e) => Some(e),
+            SetActiveError::MalformedResponse(_, ref e) => Some(e),
             SetActiveError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -822,7 +824,7 @@ where
         .map_err(SetPresenceError::Client)
         .and_then(|result| {
             serde_json::from_str::<SetPresenceResponse>(&result)
-                .map_err(SetPresenceError::MalformedResponse)
+                .map_err(|e| SetPresenceError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -876,7 +878,7 @@ pub enum SetPresenceError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -924,7 +926,7 @@ SetPresenceError::InvalidPostType => "invalid_post_type: The method was called v
 SetPresenceError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SetPresenceError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SetPresenceError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SetPresenceError::MalformedResponse(ref e) => e.description(),
+                        SetPresenceError::MalformedResponse(_, ref e) => e.description(),
                         SetPresenceError::Unknown(ref s) => s,
                         SetPresenceError::Client(ref inner) => inner.description()
                     }
@@ -932,7 +934,7 @@ SetPresenceError::RequestTimeout => "request_timeout: The method was called via 
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SetPresenceError::MalformedResponse(ref e) => Some(e),
+            SetPresenceError::MalformedResponse(_, ref e) => Some(e),
             SetPresenceError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/mods/users_profile.rs
+++ b/src/mods/users_profile.rs
@@ -34,7 +34,8 @@ where
         .send(&url, &params[..])
         .map_err(GetError::Client)
         .and_then(|result| {
-            serde_json::from_str::<GetResponse>(&result).map_err(GetError::MalformedResponse)
+            serde_json::from_str::<GetResponse>(&result)
+                .map_err(|e| GetError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -93,7 +94,7 @@ pub enum GetError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -143,7 +144,7 @@ GetError::InvalidPostType => "invalid_post_type: The method was called via a POS
 GetError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 GetError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 GetError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        GetError::MalformedResponse(ref e) => e.description(),
+                        GetError::MalformedResponse(_, ref e) => e.description(),
                         GetError::Unknown(ref s) => s,
                         GetError::Client(ref inner) => inner.description()
                     }
@@ -151,7 +152,7 @@ GetError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            GetError::MalformedResponse(ref e) => Some(e),
+            GetError::MalformedResponse(_, ref e) => Some(e),
             GetError::Client(ref inner) => Some(inner),
             _ => None,
         }
@@ -183,7 +184,8 @@ where
         .send(&url, &params[..])
         .map_err(SetError::Client)
         .and_then(|result| {
-            serde_json::from_str::<SetResponse>(&result).map_err(SetError::MalformedResponse)
+            serde_json::from_str::<SetResponse>(&result)
+                .map_err(|e| SetError::MalformedResponse(result, e))
         })
         .and_then(|o| o.into())
 }
@@ -256,7 +258,7 @@ pub enum SetError<E: Error> {
     /// The method was called via a POST request, but the POST data was either missing or truncated.
     RequestTimeout,
     /// The response was not parseable as the expected object
-    MalformedResponse(serde_json::error::Error),
+    MalformedResponse(String, serde_json::error::Error),
     /// The response returned an error that was unknown to the library
     Unknown(String),
     /// The client had an error sending the request to Slack
@@ -316,7 +318,7 @@ SetError::InvalidPostType => "invalid_post_type: The method was called via a POS
 SetError::MissingPostType => "missing_post_type: The method was called via a POST request and included a data payload, but the request did not include a Content-Type header.",
 SetError::TeamAddedToOrg => "team_added_to_org: The team associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete.",
 SetError::RequestTimeout => "request_timeout: The method was called via a POST request, but the POST data was either missing or truncated.",
-                        SetError::MalformedResponse(ref e) => e.description(),
+                        SetError::MalformedResponse(_, ref e) => e.description(),
                         SetError::Unknown(ref s) => s,
                         SetError::Client(ref inner) => inner.description()
                     }
@@ -324,7 +326,7 @@ SetError::RequestTimeout => "request_timeout: The method was called via a POST r
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
-            SetError::MalformedResponse(ref e) => Some(e),
+            SetError::MalformedResponse(_, ref e) => Some(e),
             SetError::Client(ref inner) => Some(inner),
             _ => None,
         }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,17 +1,25 @@
 use serde;
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Timestamp(f64);
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Timestamp(u64);
+
 impl From<f64> for Timestamp {
     fn from(t: f64) -> Self {
-        Timestamp(t)
+        let micro_seconds = t * 1_000_000.0;
+        Timestamp(micro_seconds as u64)
     }
 }
 
-impl std::ops::Deref for Timestamp {
-    type Target = f64;
-    fn deref(&self) -> &f64 {
-        &self.0
+impl Into<f64> for Timestamp {
+    fn into(self) -> f64 {
+        let seconds = (self.0 as f64) / 1_000_000.0;
+        seconds
+    }
+}
+impl Into<f64> for &Timestamp {
+    fn into(self) -> f64 {
+        let seconds = (self.0 as f64) / 1_000_000.0;
+        seconds
     }
 }
 
@@ -25,23 +33,24 @@ impl<'de> ::serde::Deserialize<'de> for Timestamp {
         let value = ::serde_json::Value::deserialize(deserializer)?;
         if let Some(s) = value.as_str() {
             s.parse::<f64>()
-            .map_err(|e| D::Error::custom(e))
-            .map(Into::into)
+                .map_err(|e| D::Error::custom(e))
+                .map(Into::into)
         } else if let Some(f) = value.as_f64() {
             Ok(f.into())
         } else if let Some(u) = value.as_u64() {
             Ok((u as f64).into())
         } else {
-            Err(D::Error::custom(
-                format!("expected a timestamp but got: {}", value.to_string()),
-            ))
+            Err(D::Error::custom(format!(
+                "expected a timestamp but got: {}",
+                value.to_string()
+            )))
         }
     }
 }
 
 impl Timestamp {
     pub fn to_param_value(&self) -> String {
-        let t: &f64 = self;
-        serde_json::to_string(t).unwrap()
+        let t: f64 = self.into();
+        serde_json::to_string(&t).unwrap()
     }
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,53 @@
+use serde;
+
+#[derive(Clone, Debug)]
+pub struct Timestamp(f64);
+impl From<f64> for Timestamp {
+    fn from(t: f64) -> Self {
+        Timestamp(t)
+    }
+}
+
+impl std::ops::Deref for Timestamp {
+    type Target = f64;
+    fn deref(&self) -> &f64 {
+        &self.0
+    }
+}
+
+impl<'de> ::serde::Deserialize<'de> for Timestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+    {
+        use serde::de::Error as SerdeError;
+
+        let value = ::serde_json::Value::deserialize(deserializer)?;
+        if let Some(s) = value.as_str() {
+            s.parse::<f64>()
+            .map_err(|e| D::Error::custom(e))
+            .map(Into::into)
+        } else if let Some(f) = value.as_f64() {
+            Ok(f.into())
+        } else if let Some(u) = value.as_u64() {
+            Ok((u as f64).into())
+        } else {
+            Err(D::Error::custom(
+                format!("expected a timestamp but got: {}", value.to_string()),
+            ))
+        }
+    }
+}
+
+impl Default for Timestamp {
+    fn default() -> Self {
+        0_f64.into()
+    }
+}
+
+impl Timestamp {
+    pub fn to_param_value(&self) -> String {
+        let t: &f64 = self;
+        serde_json::to_string(t).unwrap()
+    }
+}

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,6 +1,6 @@
 use serde;
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Timestamp(f64);
 impl From<f64> for Timestamp {
     fn from(t: f64) -> Self {
@@ -36,12 +36,6 @@ impl<'de> ::serde::Deserialize<'de> for Timestamp {
                 format!("expected a timestamp but got: {}", value.to_string()),
             ))
         }
-    }
-}
-
-impl Default for Timestamp {
-    fn default() -> Self {
-        0_f64.into()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -104,7 +104,7 @@ pub struct File {
     pub thumb_480_w: Option<i32>,
     pub thumb_64: Option<String>,
     pub thumb_80: Option<String>,
-    pub timestamp: Option<i32>,
+    pub timestamp: Option<crate::Timestamp>,
     pub title: Option<String>,
     pub url_private: Option<String>,
     pub url_private_download: Option<String>,
@@ -117,7 +117,7 @@ pub struct FileComment {
     pub comment: Option<String>,
     pub id: Option<String>,
     pub reactions: Option<Vec<crate::Reaction>>,
-    pub timestamp: Option<i32>,
+    pub timestamp: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
@@ -363,8 +363,8 @@ pub struct MessageBotMessage {
     pub subtype: Option<String>,
     pub team: Option<String>,
     pub text: Option<String>,
-    pub thread_ts: Option<String>,
-    pub ts: Option<String>,
+    pub thread_ts: Option<crate::Timestamp>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub username: Option<String>,
@@ -386,7 +386,7 @@ pub struct MessageBotMessageAttachment {
     pub thumb_url: Option<String>,
     pub title: Option<String>,
     pub title_link: Option<String>,
-    pub ts: Option<f32>,
+    pub ts: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -410,7 +410,7 @@ pub struct MessageChannelArchive {
     pub members: Option<Vec<String>>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -420,7 +420,7 @@ pub struct MessageChannelArchive {
 pub struct MessageChannelJoin {
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -430,7 +430,7 @@ pub struct MessageChannelJoin {
 pub struct MessageChannelLeave {
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -442,7 +442,7 @@ pub struct MessageChannelName {
     pub old_name: Option<String>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -453,7 +453,7 @@ pub struct MessageChannelPurpose {
     pub purpose: Option<String>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -464,7 +464,7 @@ pub struct MessageChannelTopic {
     pub subtype: Option<String>,
     pub text: Option<String>,
     pub topic: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -474,7 +474,7 @@ pub struct MessageChannelTopic {
 pub struct MessageChannelUnarchive {
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -486,7 +486,7 @@ pub struct MessageFileComment {
     pub file: Option<crate::File>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
 }
@@ -496,7 +496,7 @@ pub struct MessageFileMention {
     pub file: Option<crate::File>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -507,7 +507,7 @@ pub struct MessageFileShare {
     pub file: Option<crate::File>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub upload: Option<bool>,
@@ -519,7 +519,7 @@ pub struct MessageGroupArchive {
     pub members: Option<Vec<String>>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -529,7 +529,7 @@ pub struct MessageGroupArchive {
 pub struct MessageGroupJoin {
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -539,7 +539,7 @@ pub struct MessageGroupJoin {
 pub struct MessageGroupLeave {
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -551,7 +551,7 @@ pub struct MessageGroupName {
     pub old_name: Option<String>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -562,7 +562,7 @@ pub struct MessageGroupPurpose {
     pub purpose: Option<String>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -573,7 +573,7 @@ pub struct MessageGroupTopic {
     pub subtype: Option<String>,
     pub text: Option<String>,
     pub topic: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -583,7 +583,7 @@ pub struct MessageGroupTopic {
 pub struct MessageGroupUnarchive {
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -594,7 +594,7 @@ pub struct MessageMeMessage {
     pub channel: Option<String>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -603,12 +603,12 @@ pub struct MessageMeMessage {
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageChanged {
     pub channel: Option<String>,
-    pub event_ts: Option<String>,
+    pub event_ts: Option<crate::Timestamp>,
     pub hidden: Option<bool>,
     pub message: Option<MessageMessageChangedMessage>,
     pub previous_message: Option<MessageMessageChangedPreviousMessage>,
     pub subtype: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
 }
@@ -623,8 +623,8 @@ pub struct MessageMessageChangedMessage {
     pub reply_count: Option<i32>,
     pub subscribed: Option<bool>,
     pub text: Option<String>,
-    pub thread_ts: Option<String>,
-    pub ts: Option<String>,
+    pub thread_ts: Option<crate::Timestamp>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub unread_count: Option<i32>,
@@ -633,13 +633,13 @@ pub struct MessageMessageChangedMessage {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageChangedMessageEdited {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageChangedMessageReply {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
@@ -653,8 +653,8 @@ pub struct MessageMessageChangedPreviousMessage {
     pub reply_count: Option<i32>,
     pub subscribed: Option<bool>,
     pub text: Option<String>,
-    pub thread_ts: Option<String>,
-    pub ts: Option<String>,
+    pub thread_ts: Option<crate::Timestamp>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub unread_count: Option<i32>,
@@ -663,25 +663,25 @@ pub struct MessageMessageChangedPreviousMessage {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageChangedPreviousMessageEdited {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageChangedPreviousMessageReply {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageDeleted {
     pub channel: Option<String>,
-    pub deleted_ts: Option<String>,
-    pub event_ts: Option<String>,
+    pub deleted_ts: Option<crate::Timestamp>,
+    pub event_ts: Option<crate::Timestamp>,
     pub hidden: Option<bool>,
     pub previous_message: Option<MessageMessageDeletedPreviousMessage>,
     pub subtype: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
 }
@@ -696,8 +696,8 @@ pub struct MessageMessageDeletedPreviousMessage {
     pub reply_count: Option<i32>,
     pub subscribed: Option<bool>,
     pub text: Option<String>,
-    pub thread_ts: Option<String>,
-    pub ts: Option<String>,
+    pub thread_ts: Option<crate::Timestamp>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub unread_count: Option<i32>,
@@ -706,25 +706,25 @@ pub struct MessageMessageDeletedPreviousMessage {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageDeletedPreviousMessageEdited {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageDeletedPreviousMessageReply {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageReplied {
     pub channel: Option<String>,
-    pub event_ts: Option<String>,
+    pub event_ts: Option<crate::Timestamp>,
     pub hidden: Option<bool>,
     pub message: Option<MessageMessageRepliedMessage>,
     pub subtype: Option<String>,
-    pub thread_ts: Option<String>,
-    pub ts: Option<String>,
+    pub thread_ts: Option<crate::Timestamp>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
 }
@@ -739,8 +739,8 @@ pub struct MessageMessageRepliedMessage {
     pub reply_count: Option<i32>,
     pub subscribed: Option<bool>,
     pub text: Option<String>,
-    pub thread_ts: Option<String>,
-    pub ts: Option<String>,
+    pub thread_ts: Option<crate::Timestamp>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub unread_count: Option<i32>,
@@ -749,13 +749,13 @@ pub struct MessageMessageRepliedMessage {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageRepliedMessageEdited {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageMessageRepliedMessageReply {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
@@ -766,7 +766,7 @@ pub struct MessagePinnedItem {
     pub item_type: Option<String>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -779,9 +779,9 @@ pub struct MessagePinnedItemItem {}
 pub struct MessageReplyBroadcast {
     pub attachments: Option<Vec<MessageReplyBroadcastAttachment>>,
     pub channel: Option<String>,
-    pub event_ts: Option<String>,
+    pub event_ts: Option<crate::Timestamp>,
     pub subtype: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -800,7 +800,7 @@ pub struct MessageReplyBroadcastAttachment {
     pub id: Option<i32>,
     pub mrkdwn_in: Option<Vec<String>>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -809,13 +809,13 @@ pub struct MessageStandard {
     pub bot_id: Option<String>,
     pub channel: Option<String>,
     pub edited: Option<MessageStandardEdited>,
-    pub event_ts: Option<String>,
+    pub event_ts: Option<crate::Timestamp>,
     pub reply_broadcast: Option<bool>,
     pub source_team: Option<String>,
     pub team: Option<String>,
     pub text: Option<String>,
-    pub thread_ts: Option<String>,
-    pub ts: Option<String>,
+    pub thread_ts: Option<crate::Timestamp>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -837,7 +837,7 @@ pub struct MessageStandardAttachment {
     pub thumb_url: Option<String>,
     pub title: Option<String>,
     pub title_link: Option<String>,
-    pub ts: Option<f32>,
+    pub ts: Option<crate::Timestamp>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -849,7 +849,7 @@ pub struct MessageStandardAttachmentField {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct MessageStandardEdited {
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 
@@ -860,7 +860,7 @@ pub struct MessageUnpinnedItem {
     pub item_type: Option<String>,
     pub subtype: Option<String>,
     pub text: Option<String>,
-    pub ts: Option<String>,
+    pub ts: Option<crate::Timestamp>,
     #[serde(rename = "type")]
     pub ty: Option<String>,
     pub user: Option<String>,
@@ -901,12 +901,12 @@ pub struct Reaction {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Reminder {
-    pub complete_ts: Option<f32>,
+    pub complete_ts: Option<crate::Timestamp>,
     pub creator: Option<String>,
     pub id: Option<String>,
     pub recurring: Option<bool>,
     pub text: Option<String>,
-    pub time: Option<f32>,
+    pub time: Option<crate::Timestamp>,
     pub user: Option<String>,
 }
 

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -1,0 +1,77 @@
+use slack_api as slack;
+
+use std::env;
+
+fn get_setup(
+) -> Result<(String, impl slack::requests::SlackWebRequestSender), Box<dyn std::error::Error>> {
+    // You can generate a legacy token to quickly test these apis
+    // https://api.slack.com/custom-integrations/legacy-tokens
+    let token = env::var("SLACK_API_TOKEN").map_err(|_| "SLACK_API_TOKEN env var must be set")?;
+    let client = slack::default_client().map_err(|_| "Could not get default_client")?;
+    Ok((token, client))
+}
+
+#[test]
+fn smoke_test() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, client) = get_setup()?;
+
+    let resp = slack::api::test(
+        &client,
+        &slack::api::TestRequest {
+            error: Some("my_error"),
+            foo: Some("it's me, foo"),
+        },
+    )
+    .err()
+    .ok_or("Expected error")?;
+
+    assert_eq!(format!("{:?}", resp), "Unknown(\"my_error\")");
+    Ok(())
+}
+
+#[test]
+fn smoke_channels() -> Result<(), Box<dyn std::error::Error>> {
+    let (token, client) = get_setup()?;
+
+    let all_channels = slack::channels::list(
+        &client,
+        &token,
+        &slack::channels::ListRequest {
+            ..slack::channels::ListRequest::default()
+        },
+    )?
+    .channels
+    .ok_or("Expected some channels")?;
+
+    assert!(all_channels.len() > 0);
+
+    for channel in &all_channels[..10] {
+        let channel_id = channel.id.as_ref().ok_or("expected channel id")?;
+
+        let _channel_info = slack::channels::info(
+            &client,
+            &token,
+            &slack::channels::InfoRequest {
+                channel: &channel_id,
+                ..Default::default()
+            },
+        )?
+        .channel
+        .ok_or("Expected some channel")?;
+
+        let _channel_history = slack::channels::history(
+            &client,
+            &token,
+            &slack::channels::HistoryRequest {
+                channel: &channel_id,
+                oldest: Some(1234567890.1234.into()),
+                count: Some(1),
+                ..Default::default()
+            },
+        )?
+        .messages
+        .ok_or("Expected some messages")?;
+    }
+
+    Ok(())
+}

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -69,10 +69,17 @@ fn smoke_channels() -> Result<(), Box<dyn std::error::Error>> {
             &slack::channels::HistoryRequest {
                 channel: &channel_id,
                 oldest: Some(1234567890.1234.into()),
-                count: Some(1),
                 ..Default::default()
             },
-        )?
+        )
+        .map_err(|e| {
+            if let slack::channels::HistoryError::MalformedResponse(r, inner_e) = e {
+                println!("{}", r);
+                Box::new(inner_e) as Box<dyn std::error::Error>
+            } else {
+                Box::new(e)
+            }
+        })?
         .messages
         .ok_or("Expected some messages")?;
     }

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -12,6 +12,7 @@ fn get_setup(
 }
 
 #[test]
+#[ignore]
 fn smoke_test() -> Result<(), Box<dyn std::error::Error>> {
     let (_, client) = get_setup()?;
 
@@ -30,6 +31,7 @@ fn smoke_test() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+#[ignore]
 fn smoke_channels() -> Result<(), Box<dyn std::error::Error>> {
     let (token, client) = get_setup()?;
 

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -50,7 +50,7 @@ fn smoke_channels() -> Result<(), Box<dyn std::error::Error>> {
     for channel in &all_channels[..10] {
         let channel_id = channel.id.as_ref().ok_or("expected channel id")?;
 
-        let _channel_info = slack::channels::info(
+        let channel_info = slack::channels::info(
             &client,
             &token,
             &slack::channels::InfoRequest {
@@ -60,6 +60,8 @@ fn smoke_channels() -> Result<(), Box<dyn std::error::Error>> {
         )?
         .channel
         .ok_or("Expected some channel")?;
+
+        dbg!(channel_info.name);
 
         let _channel_history = slack::channels::history(
             &client,


### PR DESCRIPTION
Looking for some feedback.

have added a timestamp.json object to the schema and referenced it places that are timestamps
https://github.com/dten/slack-api-schemas/tree/timestamp

and in api updated the generator to cope with it, but in fact ignored that type and provided a custom `Timestamp` type that converts everything to f64
https://github.com/dten/slack-rs-api/tree/timestamp

added a couple of tests also, there's a test if `SLACK_API_TOKEN` is set it will try list the channels and then try get the history for the first 10. This was failing before the changes because the timestamps in the message details were often the wrong type

it's pretty similar to #56 but more complete