### PR TITLE
timestamp precision fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,33 @@ mod tests {
 
     #[test]
     fn test_timestamp_to_param_value() {
-        assert_eq!(crate::Timestamp::from(1234567.0).to_param_value(), "1234567.0");
+        assert_eq!(
+            crate::Timestamp::from(1234567.0).to_param_value(),
+            "1234567.000000"
+        );
+    }
+
+    #[test]
+    fn test_timestamp_within_message() {
+        let msg = r#"{
+            "type": "message",
+            "text": "!sqrt 2",
+            "user": "U0E000000",
+            "channel": "D00000000",
+            "event_ts": "1588861564.009805",
+            "ts": "1588861564.009805"
+        }"#;
+        let message: crate::Message = serde_json::from_str(msg).unwrap();
+        match message {
+            crate::Message::Standard(crate::MessageStandard {
+                event_ts: Some(event_ts),
+                ts: Some(ts),
+                ..
+            }) => {
+                assert_eq!(event_ts.to_param_value(), "1588861564.009805");
+                assert_eq!(ts.to_param_value(), "1588861564.009805");
+            }
+            m => panic!("expected Message::Standard but got {:?}", m),
+        };
     }
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -3,6 +3,14 @@ use serde;
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Timestamp(u64);
 
+impl std::fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let u = self.0 / 1_000_000;
+        let l = self.0 % 1_000_000;
+        write!(f, "{}.{:06}", u, l)
+    }
+}
+
 impl From<f64> for Timestamp {
     fn from(t: f64) -> Self {
         let micro_seconds = t * 1_000_000.0;
@@ -10,16 +18,18 @@ impl From<f64> for Timestamp {
     }
 }
 
-impl Into<f64> for Timestamp {
-    fn into(self) -> f64 {
-        let seconds = (self.0 as f64) / 1_000_000.0;
-        seconds
+impl From<u64> for Timestamp {
+    fn from(t: u64) -> Self {
+        let micro_seconds = t * 1_000_000;
+        Timestamp(micro_seconds)
     }
 }
-impl Into<f64> for &Timestamp {
-    fn into(self) -> f64 {
-        let seconds = (self.0 as f64) / 1_000_000.0;
-        seconds
+
+impl From<(u64, f64)> for Timestamp {
+    fn from(ts: (u64, f64)) -> Self {
+        let (ti, td) = ts;
+        let micro_seconds = ti * 1_000_000 + (td * 1_000_000.0) as u64;
+        Timestamp(micro_seconds)
     }
 }
 
@@ -30,12 +40,29 @@ impl<'de> ::serde::Deserialize<'de> for Timestamp {
     {
         use serde::de::Error as SerdeError;
 
+        // slack seems to use strings sometimes to
+        // maintain precision greater than what f64 is happy with
+        // so custom parser to get the f128 out of the string
+        
         let value = ::serde_json::Value::deserialize(deserializer)?;
+
         if let Some(s) = value.as_str() {
-            s.parse::<f64>()
-                .map_err(|e| D::Error::custom(e))
-                .map(Into::into)
-        } else if let Some(f) = value.as_f64() {
+            if let Some(dot_index) = s.find('.') {
+                // must be f128 in string
+                let i = s[..dot_index].parse::<u64>();
+                let d = s[dot_index..].parse::<f64>();
+                if let (Ok(i), Ok(d)) = (i, d) {
+                    return Ok((i, d).into())
+                }
+            } else {
+                // must be u64 in a string
+                if let Ok(u) = s.parse::<u64>() {
+                    return Ok(u.into())
+                }
+            }
+        }
+
+        if let Some(f) = value.as_f64() {
             Ok(f.into())
         } else if let Some(u) = value.as_u64() {
             Ok((u as f64).into())
@@ -50,7 +77,43 @@ impl<'de> ::serde::Deserialize<'de> for Timestamp {
 
 impl Timestamp {
     pub fn to_param_value(&self) -> String {
-        let t: f64 = self.into();
-        serde_json::to_string(&t).unwrap()
+        format!("{}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserve_precision_f64() {
+        let ts_str = "1588859442.008705";
+        let ts: Timestamp = serde_json::from_str(ts_str).unwrap();
+        assert_eq!(ts, Timestamp(1588859442008705));
+        assert_eq!(ts.to_param_value(), "1588859442.008705");
+    }
+
+    #[test]
+    fn preserve_precision_str() {
+        let ts_str = "\"1588859442.008705\"";
+        let ts: Timestamp = serde_json::from_str(ts_str).unwrap();
+        assert_eq!(ts, Timestamp(1588859442008705));
+        assert_eq!(ts.to_param_value(), "1588859442.008705");
+    }
+
+    #[test]
+    fn preserve_precision_str_0_dp() {
+        let ts_str = "\"1588859442\"";
+        let ts: Timestamp = serde_json::from_str(ts_str).unwrap();
+        assert_eq!(ts, Timestamp(1588859442000000));
+        assert_eq!(ts.to_param_value(), "1588859442.000000");
+    }
+
+    #[test]
+    fn preserve_precision_str_1_dp() {
+        let ts_str = "\"1588859442.1\"";
+        let ts: Timestamp = serde_json::from_str(ts_str).unwrap();
+        assert_eq!(ts, Timestamp(1588859442100000));
+        assert_eq!(ts.to_param_value(), "1588859442.100000");
     }
 }


### PR DESCRIPTION
as was speculated many moons ago by @saethlin f64 did not have enough precision
slack seems to use a string if f64 isn't enough precision, so in the string parsing case only parse the decimal part as an f64 before scaling it up and adding to the rest as u64

includes tests now!

also removes Timestamp into f64 as it's not safe but adds Display / to_string